### PR TITLE
Issue14

### DIFF
--- a/docs/tutorials/CodelistPhenotype_Tutorial.ipynb
+++ b/docs/tutorials/CodelistPhenotype_Tutorial.ipynb
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from phenex.phenotypes.codelist_phenotype import CodelistPhenotype\n",
+    "from phenex.phenotypes import CodelistPhenotype\n",
     "# Ex.1 \n",
     "# Which patients had an atrial fibrillation diagnosis at **any time** in the data source?\n",
     "af_phenotype = CodelistPhenotype(\n",
@@ -197,7 +197,7 @@
    "outputs": [],
    "source": [
     "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.operations.filters import (\n",
+    "from phenex.filters import (\n",
     "    GreaterThanOrEqualTo,\n",
     "    LessThan,\n",
     "    RelativeTimeRangeFilter, \n",
@@ -271,7 +271,7 @@
    "outputs": [],
    "source": [
     "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.operations.filters import (\n",
+    "from phenex.filters import (\n",
     "    LessThanOrEqualTo,\n",
     "    RelativeTimeRangeFilter\n",
     ")\n",
@@ -337,7 +337,7 @@
    "outputs": [],
    "source": [
     "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.operations.filters import (\n",
+    "from phenex.filters import (\n",
     "    CategoricalFilter\n",
     ")\n",
     "\n",
@@ -379,7 +379,7 @@
    "outputs": [],
    "source": [
     "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.operations.filters import (\n",
+    "from phenex.filters import (\n",
     "    CategoricalFilter\n",
     ")\n",
     "\n",
@@ -429,7 +429,7 @@
    "outputs": [],
    "source": [
     "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.operations.filters import (\n",
+    "from phenex.filters import (\n",
     "    LessThanOrEqualTo,\n",
     "    RelativeTimeRangeFilter, \n",
     "    CategoricalFilter\n",
@@ -499,8 +499,7 @@
    "outputs": [],
    "source": [
     "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.phenotypes import CodelistPhenotype\n",
-    "from phenex.operations.filters import (\n",
+    "from phenex.filters import (\n",
     "    LessThanOrEqualTo,\n",
     "    RelativeTimeRangeFilter, \n",
     ")\n",

--- a/docs/tutorials/CodelistPhenotype_Tutorial.ipynb
+++ b/docs/tutorials/CodelistPhenotype_Tutorial.ipynb
@@ -368,7 +368,8 @@
    "metadata": {},
    "source": [
     "<a id='example_7'></a>\n",
-    "#### Example 7"
+    "# CURRENTLY NOT IMPLEMENTED\n",
+    "#### ~Example 7~"
    ]
   },
   {

--- a/phenex/filters/__init__.py
+++ b/phenex/filters/__init__.py
@@ -1,1 +1,2 @@
 from .relative_time_range_filter import RelativeTimeRangeFilter
+from .value import GreaterThan, GreaterThanOrEqualTo, LessThan, LessThanOrEqualTo, EqualTo, Value

--- a/phenex/filters/categorical_filter.py
+++ b/phenex/filters/categorical_filter.py
@@ -30,7 +30,10 @@ class CategoricalFilter(Filter):
         self.domain = domain
         super(CategoricalFilter, self).__init__()
 
-    def _filter(self, table: 'PhenexTable', tables:dict = None):
+    def _filter(self, table: 'PhenexTable'):
+        return table.filter(table[self.column_name].isin(self.allowed_values))
+
+    def autojoin_filter(self, table: 'PhenexTable', tables:dict = None):
         if self.column_name not in table.columns:
             if self.domain not in tables.keys():
                 raise ValueError(f"Table required for categorical filter ({self.domain}) does not exist within domains dicitonary")

--- a/phenex/filters/categorical_filter.py
+++ b/phenex/filters/categorical_filter.py
@@ -30,7 +30,7 @@ class CategoricalFilter(Filter):
         self.domain = domain
         super(CategoricalFilter, self).__init__()
 
-    def _filter(self, table: 'PhenexTable', tables:dict):
+    def _filter(self, table: 'PhenexTable', tables:dict = None):
         if self.column_name not in table.columns:
             if self.domain not in tables.keys():
                 raise ValueError(f"Table required for categorical filter ({self.domain}) does not exist within domains dicitonary")

--- a/phenex/filters/categorical_filter.py
+++ b/phenex/filters/categorical_filter.py
@@ -30,6 +30,10 @@ class CategoricalFilter(Filter):
         self.domain = domain
         super(CategoricalFilter, self).__init__()
 
-    def _filter(self, table: Table):
-        table = table.filter(table[self.column_name].isin(self.allowed_values))
-        return table
+    def _filter(self, table: 'PhenexTable', tables:dict):
+        if self.column_name not in table.columns:
+            if self.domain not in tables.keys():
+                raise ValueError(f"Table required for categorical filter ({self.domain}) does not exist within domains dicitonary")
+            table = table.join(tables[self.domain], domains = tables)
+            # TODO downselect to original columns
+        return table.filter(table[self.column_name].isin(self.allowed_values))

--- a/phenex/filters/codelist_filter.py
+++ b/phenex/filters/codelist_filter.py
@@ -58,4 +58,5 @@ class CodelistFilter(Filter):
             code_table.columns
         )
 
-        return filtered_table.select(input_columns)
+        # return table with downselected columns, of same type as input table
+        return type(code_table)(filtered_table.select(input_columns))

--- a/phenex/mappers.py
+++ b/phenex/mappers.py
@@ -69,12 +69,14 @@ class DomainsDictionary:
 # OMOP Column Mappers
 #
 class OMOPPersonTable(PhenexPersonTable):
+    NAME_TABLE = 'PERSON'
     JOIN_KEYS = {
         'OMOPConditionOccurenceTable': ['PERSON_ID'],
         'OMOPVisitDetailTable': ['PERSON_ID']
     }
 
 class OMOPVisitDetailTable(PhenexVisitDetailTable):
+    NAME_TABLE = 'VISIT_DETAIL'
     JOIN_KEYS = {
         'OMOPPersonTable': ['PERSON_ID'],
         'OMOPConditionOccurenceTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
@@ -92,89 +94,119 @@ class OMOPConditionOccurenceTable(CodeTable):
         'CODE': "CONDITION_CONCEPT_ID",
     }
 
+class OMOPDeathTable(PhenexTable):
+    NAME_TABLE = 'DEATH'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID']
+    }
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'DATE_OF_DEATH'
+    ]
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'DATE_OF_DEATH': "DEATH_DATE"
+    }
+
+class OMOPProcedureOccurrenceTable(CodeTable):
+    NAME_TABLE = 'PROCEDURE_OCCURRENCE'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "PROCEDURE_DATE",
+        'CODE': "PROCEDURE_CONCEPT_ID",
+    }
+
+class OMOPDrugExposureTable(CodeTable):
+    NAME_TABLE = 'DRUG_EXPOSURE'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "DRUG_EXPOSURE_START_DATE",
+        'CODE': "DRUG_CONCEPT_ID",
+    }
+
+class OMOPConditionOccurrenceSourceTable(CodeTable):
+    NAME_TABLE = 'CONDITION_OCCURRENCE'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "CONDITION_START_DATE",
+        'CODE': "CONDITION_SOURCE_VALUE",
+    }
+
+class OMOPProcedureOccurrenceSourceTable(CodeTable):
+    NAME_TABLE = 'PROCEDURE_OCCURRENCE'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "PROCEDURE_DATE",
+        'CODE': "PROCEDURE_SOURCE_VALUE",
+    }
+
+class OMOPDrugExposureSourceTable(CodeTable):
+    NAME_TABLE = 'DRUG_EXPOSURE'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "DRUG_EXPOSURE_START_DATE",
+        'CODE': "DRUG_SOURCE_VALUE",
+    }
+
+class OMOPPersonTableSource(PhenexPersonTable):
+    NAME_TABLE = 'PERSON'
+    JOIN_KEYS = {
+        'OMOPConditionOccurenceTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'DATE_OF_BIRTH': "BIRTH_DATETIME",
+        'YEAR_OF_BIRTH': "YEAR_OF_BIRTH",
+        'SEX': "GENDER_SOURCE_VALUE",
+        'ETHNICITY': "ETHNICITY_SOURCE_VALUE",
+    }
+
+class OMOPObservationPeriodTable(PhenexObservationPeriodTable):
+    NAME_TABLE = 'OBSERVATION_PERIOD'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID']
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'OBSERVATION_PERIOD_START_DATE': "OBSERVATION_PERIOD_START_DATE",
+        'OBSERVATION_PERIOD_END_DATE': 'OBSERVATION_PERIOD_END_DATE'
+    }
+
 #
 # Domains
 #
 OMOPs = {
     "PERSON": OMOPPersonTable,
-    "VISIT": OMOPVisitDetailTable,
+    "VISIT_DETAIL": OMOPVisitDetailTable,
     "CONDITION_OCCURRENCE": OMOPConditionOccurenceTable,
-    # "DEATH": OMOPDeathTable,
-    # "CONDITION_OCCURRENCE": OMOPConditionOccurrence,
-    # "PROCEDURE_OCCURRENCE": OMOPProcedureOccurrence,
-    # "DRUG_EXPOSURE": OMOPDrugExposure,
-    # "PERSON_SOURCE": OMOPPersonTableSource,
-    # "CONDITION_OCCURRENCE_SOURCE": OMOPConditionOccurrenceSource,
-    # "PROCEDURE_OCCURRENCE_SOURCE": OMOPProcedureOccurrenceSource,
-    # "DRUG_EXPOSURE_SOURCE": OMOPDrugExposureSource,
-    # "OBSERVATION_PERIOD": OMOPObservationPeriod,
+    "DEATH": OMOPDeathTable,
+    "PROCEDURE_OCCURRENCE": OMOPProcedureOccurrenceTable,
+    "DRUG_EXPOSURE": OMOPDrugExposureTable,
+    "CONDITION_OCCURRENCE_SOURCE": OMOPConditionOccurrenceSourceTable,
+    "PROCEDURE_OCCURRENCE_SOURCE": OMOPProcedureOccurrenceSourceTable,
+    "DRUG_EXPOSURE_SOURCE": OMOPDrugExposureSourceTable,
+    "PERSON_SOURCE": OMOPPersonTableSource,
+    "OBSERVATION_PERIOD": OMOPObservationPeriodTable,
 }
 OMOPDomains = DomainsDictionary(OMOPs)
-
-#
-# OLD vvvvv
-#
-# OMOPPersonTable = PersonTable(
-#     NAME_TABLE="PERSON",
-#     PERSON_ID="PERSON_ID",
-#     DATE_OF_BIRTH="BIRTH_DATETIME",
-#     YEAR_OF_BIRTH="YEAR_OF_BIRTH",
-#     SEX="GENDER_CONCEPT_ID",
-#     ETHNICITY="ETHNICITY_CONCEPT_ID",
-# )
-
-# OMOPDeathTable = PersonTable(
-#     NAME_TABLE="DEATH", PERSON_ID="PERSON_ID", DATE_OF_DEATH="DEATH_DATE"
-# )
-
-# OMOPPersonTableSource = PersonTable(
-#     NAME_TABLE="PERSON",
-#     PERSON_ID="PERSON_ID",
-#     DATE_OF_BIRTH="BIRTH_DATETIME",
-#     YEAR_OF_BIRTH="YEAR_OF_BIRTH",
-#     SEX="GENDER_SOURCE_VALUE",
-#     ETHNICITY="ETHNICITY_SOURCE_VALUE",
-# )
-
-# OMOPConditionOccurrence = CodeTable(
-#     NAME_TABLE="CONDITION_OCCURRENCE",
-#     EVENT_DATE="CONDITION_START_DATE",
-#     CODE="CONDITION_CONCEPT_ID",
-# )
-
-# OMOPConditionOccurrenceSource = CodeTable(
-#     NAME_TABLE="CONDITION_OCCURRENCE",
-#     EVENT_DATE="CONDITION_START_DATE",
-#     CODE="CONDITION_SOURCE_VALUE",
-# )
-
-# OMOPProcedureOccurrence = CodeTable(
-#     NAME_TABLE="PROCEDURE_OCCURRENCE",
-#     EVENT_DATE="PROCEDURE_DATE",
-#     CODE="PROCEDURE_CONCEPT_ID",
-# )
-
-# OMOPProcedureOccurrenceSource = CodeTable(
-#     NAME_TABLE="PROCEDURE_OCCURRENCE",
-#     EVENT_DATE="PROCEDURE_DATE",
-#     CODE="PROCEDURE_SOURCE_VALUE",
-# )
-
-# OMOPDrugExposure = CodeTable(
-#     NAME_TABLE="DRUG_EXPOSURE",
-#     EVENT_DATE="DRUG_EXPOSURE_START_DATE",
-#     CODE="DRUG_CONCEPT_ID",
-# )
-
-# OMOPDrugExposureSource = CodeTable(
-#     NAME_TABLE="DRUG_EXPOSURE",
-#     EVENT_DATE="DRUG_EXPOSURE_START_DATE",
-#     CODE="DRUG_SOURCE_VALUE",
-# )
-
-# OMOPObservationPeriod = PhenexObservationPeriodTable(
-#     NAME_TABLE="OBSERVATION_PERIOD",
-#     PERSON_ID="PERSON_ID",
-#     OBSERVATION_PERIOD_START_DATE="OBSERVATION_PERIOD_START_DATE",
-#     OBSERVATION_PERIOD_END_DATE="OBSERVATION_PERIOD_END_DATE",
-# )

--- a/phenex/mappers.py
+++ b/phenex/mappers.py
@@ -3,113 +3,7 @@ from typing import Optional, Dict
 from dataclasses import dataclass, asdict
 from ibis.expr.types.relations import Table
 
-
-@dataclass
-class ColumnMapper:
-    """
-    The ColumnMapper class provides a template for mapping columns of a table from an arbitrary schema to an internal representation.
-
-    To subclass:
-        1. Check whether one of the existing ColumnMapper's fits your use case.
-        2. If not, define a new one by specifying the columns understood by the new ColumnMapper and adding those which are required to required_columns.
-
-    Attributes:
-        NAME_TABLE: The name of the table to be mapped.
-        required_columns: The columns which must always be specified when using the give ColumnMapper.
-
-    Methods:
-        rename(table: Table) -> Table:
-            Renames the columns of the given table according to the internal representation.
-    """
-
-    NAME_TABLE: str
-    required_columns = []
-
-    def rename(self, table: Table) -> Table:
-        """
-        Renames the columns of the given table according to the internal representation.
-
-        Args:
-            table (Table): The table to rename columns for.
-
-        Returns:
-            Table: The table with renamed columns.
-        """
-        mapping = copy.deepcopy(asdict(self))
-        mapping.pop("NAME_TABLE")
-        # delete optional params from mapping
-        for key in asdict(self).keys():
-            if key not in self.required_columns and getattr(self, key) is None:
-                del mapping[key]
-        return table.rename(**mapping)
-
-
-@dataclass
-class PersonTableColumnMapper(ColumnMapper):
-    """
-    Maps columns of a "person-like" table from an arbitrary schema to a PhenEx internal representation. A "person-like" table is a table that contains basic information about the patients in a database, generally characteristics that are time-independent (such as date of birth, race, sex at birth). These tables are required in the computation of PersonPhenotype's.
-
-    Attributes:
-        PERSON_ID (str): The column name for the person ID.
-        DATE_OF_BIRTH (str): The column name for the date of birth.
-    """
-
-    NAME_TABLE: str = "PERSON"
-    PERSON_ID: str = "PERSON_ID"
-    DATE_OF_BIRTH: Optional[str] = None
-    YEAR_OF_BIRTH: Optional[str] = None
-    DATE_OF_DEATH: Optional[str] = None
-    SEX: Optional[str] = None
-    ETHNICITY: Optional[str] = None
-    required_columns = ['PERSON_ID']
-
-
-@dataclass
-class CodeTableColumnMapper(ColumnMapper):
-    """
-    Maps columns of a code table from an arbitrary schema to an internal representation. A code table is a table that contains coded information about events or conditions related to patients, such as diagnoses, procedures, or medications. These tables typically include an event date, a code representing the event or condition, and optionally a code type.
-
-    Attributes:
-        EVENT_DATE (str): The column name for the event date.
-        CODE (str): The column name for the code.
-        CODE_TYPE (Optional[str]): The column name for the code type, if applicable.
-        PERSON_ID (str): The column name for the person ID.
-    """
-
-    NAME_TABLE: str
-    EVENT_DATE: str = "EVENT_DATE"
-    CODE: str = "CODE"
-    CODE_TYPE: Optional[str] = None
-    PERSON_ID: str = "PERSON_ID"
-
-    # some code tables do not have CODE_TYPE
-    required_columns = ['PERSON_ID', 'EVENT_DATE', 'CODE']
-
-
-@dataclass
-class MeasurementTableColumnMapper(CodeTableColumnMapper):
-    """
-    Maps columns of a measurement table from an arbitrary schema to an internal representation.A measurement table is a table that contains code information associated with a numerical value, for example lab test results.
-
-    Attributes:
-        EVENT_DATE (str): The column name for the event date.
-        CODE (str): The column name for the code.
-        CODE_TYPE (Optional[str]): The column name for the code type, if applicable.
-        PERSON_ID (str): The column name for the person ID.
-        VALUE (str): The column name for the value.
-    """
-
-    VALUE: str = "VALUE"
-    required_columns = ['PERSON_ID', 'EVENT_DATE', 'CODE', 'VALUE']
-
-
-@dataclass
-class ObservationPeriodTableMapper(ColumnMapper):
-    NAME_TABLE: str = "OBSERVATION_PERIOD"
-    PERSON_ID: str = "PERSON_ID"
-    OBSERVATION_PERIOD_START_DATE: str = "OBSERVATION_PERIOD_START_DATE"
-    OBSERVATION_PERIOD_END_DATE: str = "OBSERVATION_PERIOD_END_DATE"
-    required_columns = ['PERSON_ID', 'OBSERVATION_PERIOD_START_DATE', 'OBSERVATION_PERIOD_END_DATE']
+from phenex.tables import *
 
 
 class DomainsDictionary:
@@ -117,17 +11,17 @@ class DomainsDictionary:
     A DomainsDictionary is used to map an entire database from an arbitrary schema to a PhenEx internal representation.
 
     Attributes:
-        domains_dict (Dict[str, ColumnMapper]): A dictionary where keys are domain names and values are ColumnMapper instances.
+        domains_dict (Dict[str, ]): A dictionary where keys are domain names and values are  instances.
 
     Methods:
         get_mapped_tables(con, database=None) -> Dict[str, Table]:
             Get all tables mapped to PhenEx representation using the given connection.
     """
 
-    def __init__(self, domains_dict: Dict[str, ColumnMapper]):
+    def __init__(self, domains_dict):
         self.domains_dict = domains_dict
 
-    def get_mapped_tables(self, con, database=None) -> Dict[str, Table]:
+    def set_mapped_tables(self, con, overwrite=False) -> Dict[str, Table]:
         """
         Get all tables mapped to PhenEx representation using the given connection.
 
@@ -140,98 +34,154 @@ class DomainsDictionary:
         Returns:
             Dict[str, Table]: A dictionary where keys are domain names and values are mapped tables.
         """
+        existing_tables = con.dest_connection.list_tables(database=con.SNOWFLAKE_DEST_DATABASE)
+        for domain, mapper in self.domains_dict.items():
+            if domain not in existing_tables or overwrite:
+                t = con.source_connection.table(
+                    mapper.NAME_TABLE,
+                    database=con.SNOWFLAKE_SOURCE_DATABASE
+                )
+                mapped_table = mapper(t).table
+                con.dest_connection.create_view(
+                    name=mapper.NAME_TABLE,
+                    database=con.SNOWFLAKE_DEST_DATABASE,
+                    obj=mapped_table,
+                    overwrite=overwrite
+                )
+
+    def get_mapped_tables(self, con) -> Dict[str, Table]:
+        """
+        Get all tables mapped to PhenEx representation using the given connection.
+
+        If a database is not provided, the current database of the connection is used to find the tables.
+
+        Args:
+            con: The connection to the database.
+            database (Optional[str]): The name of the database. Defaults to the current database of the connection.
+
+        Returns:
+            Dict[str, Table]: A dictionary where keys are domain names and values are mapped tables.
+        """
+        # self.set_mapped_tables(con)
         mapped_tables = {}
         for domain, mapper in self.domains_dict.items():
-            t = con.get_source_table(
-                mapper.NAME_TABLE
-            )
-            mapped_tables[domain] = mapper.rename(t)
+            mapped_tables[domain] = mapper(con.dest_connection.table(
+                mapper.NAME_TABLE,
+                database=con.SNOWFLAKE_DEST_DATABASE
+            ))
         return mapped_tables
 
 
 #
 # OMOP Column Mappers
 #
-OMOPPersonTableColumnMapper = PersonTableColumnMapper(
-    NAME_TABLE="PERSON",
-    PERSON_ID="PERSON_ID",
-    DATE_OF_BIRTH="BIRTH_DATETIME",
-    YEAR_OF_BIRTH="YEAR_OF_BIRTH",
-    SEX="GENDER_CONCEPT_ID",
-    ETHNICITY="ETHNICITY_CONCEPT_ID",
-)
+class OMOPPersonTable(PhenexPersonTable):
+    JOIN_KEYS = {
+        'OMOPConditionOccurenceTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID']
+    }
+    
+class OMOPVisitDetailTable(PhenexVisitDetailTable):
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPConditionOccurenceTable': ['PERSON_ID', 'VISIT_DETAIL_ID']
+    }
 
-OMOPDeathTableColumnMapper = PersonTableColumnMapper(
-    NAME_TABLE="DEATH", PERSON_ID="PERSON_ID", DATE_OF_DEATH="DEATH_DATE"
-)
-
-OMOPPersonTableSourceColumnMapper = PersonTableColumnMapper(
-    NAME_TABLE="PERSON",
-    PERSON_ID="PERSON_ID",
-    DATE_OF_BIRTH="BIRTH_DATETIME",
-    YEAR_OF_BIRTH="YEAR_OF_BIRTH",
-    SEX="GENDER_SOURCE_VALUE",
-    ETHNICITY="ETHNICITY_SOURCE_VALUE",
-)
-
-OMOPConditionOccurrenceColumnMapper = CodeTableColumnMapper(
-    NAME_TABLE="CONDITION_OCCURRENCE",
-    EVENT_DATE="CONDITION_START_DATE",
-    CODE="CONDITION_CONCEPT_ID",
-)
-
-OMOPConditionOccurrenceSourceColumnMapper = CodeTableColumnMapper(
-    NAME_TABLE="CONDITION_OCCURRENCE",
-    EVENT_DATE="CONDITION_START_DATE",
-    CODE="CONDITION_SOURCE_VALUE",
-)
-
-OMOPProcedureOccurrenceColumnMapper = CodeTableColumnMapper(
-    NAME_TABLE="PROCEDURE_OCCURRENCE",
-    EVENT_DATE="PROCEDURE_DATE",
-    CODE="PROCEDURE_CONCEPT_ID",
-)
-
-OMOPProcedureOccurrenceSourceColumnMapper = CodeTableColumnMapper(
-    NAME_TABLE="PROCEDURE_OCCURRENCE",
-    EVENT_DATE="PROCEDURE_DATE",
-    CODE="PROCEDURE_SOURCE_VALUE",
-)
-
-OMOPDrugExposureColumnMapper = CodeTableColumnMapper(
-    NAME_TABLE="DRUG_EXPOSURE",
-    EVENT_DATE="DRUG_EXPOSURE_START_DATE",
-    CODE="DRUG_CONCEPT_ID",
-)
-
-OMOPDrugExposureSourceColumnMapper = CodeTableColumnMapper(
-    NAME_TABLE="DRUG_EXPOSURE",
-    EVENT_DATE="DRUG_EXPOSURE_START_DATE",
-    CODE="DRUG_SOURCE_VALUE",
-)
-
-OMOPObservationPeriodColumnMapper = ObservationPeriodTableMapper(
-    NAME_TABLE="OBSERVATION_PERIOD",
-    PERSON_ID="PERSON_ID",
-    OBSERVATION_PERIOD_START_DATE="OBSERVATION_PERIOD_START_DATE",
-    OBSERVATION_PERIOD_END_DATE="OBSERVATION_PERIOD_END_DATE",
-)
-
-OMOPColumnMappers = {
-    "PERSON": OMOPPersonTableColumnMapper,
-    "DEATH": OMOPDeathTableColumnMapper,
-    "CONDITION_OCCURRENCE": OMOPConditionOccurrenceColumnMapper,
-    "PROCEDURE_OCCURRENCE": OMOPProcedureOccurrenceColumnMapper,
-    "DRUG_EXPOSURE": OMOPDrugExposureColumnMapper,
-    "PERSON_SOURCE": OMOPPersonTableSourceColumnMapper,
-    "CONDITION_OCCURRENCE_SOURCE": OMOPConditionOccurrenceSourceColumnMapper,
-    "PROCEDURE_OCCURRENCE_SOURCE": OMOPProcedureOccurrenceSourceColumnMapper,
-    "DRUG_EXPOSURE_SOURCE": OMOPDrugExposureSourceColumnMapper,
-    "OBSERVATION_PERIOD": OMOPObservationPeriodColumnMapper,
-}
-
+class OMOPConditionOccurenceTable(CodeTable):
+    NAME_TABLE = 'CONDITION_OCCURRENCE'
+    JOIN_KEYS = {
+        'OMOPPersonTable': ['PERSON_ID'],
+        'OMOPVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID'] # I changed this from EVENT_DATE
+    }
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "CONDITION_START_DATE",
+        'CODE': "CONDITION_CONCEPT_ID",
+    }
 
 #
 # Domains
 #
-OMOPDomains = DomainsDictionary(OMOPColumnMappers)
+OMOPs = {
+    "PERSON": OMOPPersonTable,
+    "VISIT": OMOPVisitDetailTable,
+    "CONDITION_OCCURRENCE": OMOPConditionOccurenceTable,
+    # "DEATH": OMOPDeathTable,
+    # "CONDITION_OCCURRENCE": OMOPConditionOccurrence,
+    # "PROCEDURE_OCCURRENCE": OMOPProcedureOccurrence,
+    # "DRUG_EXPOSURE": OMOPDrugExposure,
+    # "PERSON_SOURCE": OMOPPersonTableSource,
+    # "CONDITION_OCCURRENCE_SOURCE": OMOPConditionOccurrenceSource,
+    # "PROCEDURE_OCCURRENCE_SOURCE": OMOPProcedureOccurrenceSource,
+    # "DRUG_EXPOSURE_SOURCE": OMOPDrugExposureSource,
+    # "OBSERVATION_PERIOD": OMOPObservationPeriod,
+}
+OMOPDomains = DomainsDictionary(OMOPs)
+
+#
+# OLD vvvvv
+#
+# OMOPPersonTable = PersonTable(
+#     NAME_TABLE="PERSON",
+#     PERSON_ID="PERSON_ID",
+#     DATE_OF_BIRTH="BIRTH_DATETIME",
+#     YEAR_OF_BIRTH="YEAR_OF_BIRTH",
+#     SEX="GENDER_CONCEPT_ID",
+#     ETHNICITY="ETHNICITY_CONCEPT_ID",
+# )
+
+# OMOPDeathTable = PersonTable(
+#     NAME_TABLE="DEATH", PERSON_ID="PERSON_ID", DATE_OF_DEATH="DEATH_DATE"
+# )
+
+# OMOPPersonTableSource = PersonTable(
+#     NAME_TABLE="PERSON",
+#     PERSON_ID="PERSON_ID",
+#     DATE_OF_BIRTH="BIRTH_DATETIME",
+#     YEAR_OF_BIRTH="YEAR_OF_BIRTH",
+#     SEX="GENDER_SOURCE_VALUE",
+#     ETHNICITY="ETHNICITY_SOURCE_VALUE",
+# )
+
+# OMOPConditionOccurrence = CodeTable(
+#     NAME_TABLE="CONDITION_OCCURRENCE",
+#     EVENT_DATE="CONDITION_START_DATE",
+#     CODE="CONDITION_CONCEPT_ID",
+# )
+
+# OMOPConditionOccurrenceSource = CodeTable(
+#     NAME_TABLE="CONDITION_OCCURRENCE",
+#     EVENT_DATE="CONDITION_START_DATE",
+#     CODE="CONDITION_SOURCE_VALUE",
+# )
+
+# OMOPProcedureOccurrence = CodeTable(
+#     NAME_TABLE="PROCEDURE_OCCURRENCE",
+#     EVENT_DATE="PROCEDURE_DATE",
+#     CODE="PROCEDURE_CONCEPT_ID",
+# )
+
+# OMOPProcedureOccurrenceSource = CodeTable(
+#     NAME_TABLE="PROCEDURE_OCCURRENCE",
+#     EVENT_DATE="PROCEDURE_DATE",
+#     CODE="PROCEDURE_SOURCE_VALUE",
+# )
+
+# OMOPDrugExposure = CodeTable(
+#     NAME_TABLE="DRUG_EXPOSURE",
+#     EVENT_DATE="DRUG_EXPOSURE_START_DATE",
+#     CODE="DRUG_CONCEPT_ID",
+# )
+
+# OMOPDrugExposureSource = CodeTable(
+#     NAME_TABLE="DRUG_EXPOSURE",
+#     EVENT_DATE="DRUG_EXPOSURE_START_DATE",
+#     CODE="DRUG_SOURCE_VALUE",
+# )
+
+# OMOPObservationPeriod = ObservationPeriodTableMapper(
+#     NAME_TABLE="OBSERVATION_PERIOD",
+#     PERSON_ID="PERSON_ID",
+#     OBSERVATION_PERIOD_START_DATE="OBSERVATION_PERIOD_START_DATE",
+#     OBSERVATION_PERIOD_END_DATE="OBSERVATION_PERIOD_END_DATE",
+# )

--- a/phenex/mappers.py
+++ b/phenex/mappers.py
@@ -80,7 +80,7 @@ class OMOPPersonTable(PhenexPersonTable):
         'OMOPConditionOccurenceTable': ['PERSON_ID'],
         'OMOPVisitDetailTable': ['PERSON_ID']
     }
-    
+
 class OMOPVisitDetailTable(PhenexVisitDetailTable):
     JOIN_KEYS = {
         'OMOPPersonTable': ['PERSON_ID'],
@@ -179,7 +179,7 @@ OMOPDomains = DomainsDictionary(OMOPs)
 #     CODE="DRUG_SOURCE_VALUE",
 # )
 
-# OMOPObservationPeriod = ObservationPeriodTableMapper(
+# OMOPObservationPeriod = PhenexObservationPeriodTable(
 #     NAME_TABLE="OBSERVATION_PERIOD",
 #     PERSON_ID="PERSON_ID",
 #     OBSERVATION_PERIOD_START_DATE="OBSERVATION_PERIOD_START_DATE",

--- a/phenex/mappers.py
+++ b/phenex/mappers.py
@@ -70,6 +70,10 @@ class DomainsDictionary:
 #
 class OMOPPersonTable(PhenexPersonTable):
     NAME_TABLE = 'PERSON'
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'DATE_OF_BIRTH': 'BIRTH_DATETIME'
+    }    
     JOIN_KEYS = {
         'OMOPConditionOccurenceTable': ['PERSON_ID'],
         'OMOPVisitDetailTable': ['PERSON_ID']

--- a/phenex/phenotypes/codelist_phenotype.py
+++ b/phenex/phenotypes/codelist_phenotype.py
@@ -69,11 +69,13 @@ class CodelistPhenotype(Phenotype):
             RelativeTimeRangeFilter, List[RelativeTimeRangeFilter]
         ] = None,
         return_date="first",
+        categorical_filter: 'CategoricalFilter' = None
     ):
         super(CodelistPhenotype, self).__init__()
 
         self.codelist_filter = CodelistFilter(codelist, use_code_type=use_code_type)
         self.codelist = codelist
+        self.categorical_filter = categorical_filter
         self.name = name or self.codelist.name
         self.date_range = date_range
         self.return_date = return_date
@@ -97,6 +99,7 @@ class CodelistPhenotype(Phenotype):
     def _execute(self, tables) -> PhenotypeTable:
         code_table = tables[self.domain]
         code_table = self._perform_codelist_filtering(code_table)
+        code_table = self._perform_categorical_filtering(code_table, tables)
         code_table = self._perform_time_filtering(code_table)
         code_table = self._perform_date_selection(code_table)
         return select_phenotype_columns(code_table)
@@ -104,6 +107,12 @@ class CodelistPhenotype(Phenotype):
     def _perform_codelist_filtering(self, code_table):
         assert is_phenex_code_table(code_table)
         code_table = self.codelist_filter.filter(code_table)
+        return code_table
+
+    def _perform_categorical_filtering(self, code_table, tables):
+        if self.categorical_filter is not None:
+            assert is_phenex_code_table(code_table)
+            code_table = self.categorical_filter.filter(code_table, tables)
         return code_table
 
     def _perform_time_filtering(self, code_table):

--- a/phenex/phenotypes/codelist_phenotype.py
+++ b/phenex/phenotypes/codelist_phenotype.py
@@ -112,7 +112,7 @@ class CodelistPhenotype(Phenotype):
     def _perform_categorical_filtering(self, code_table, tables):
         if self.categorical_filter is not None:
             assert is_phenex_code_table(code_table)
-            code_table = self.categorical_filter.filter(code_table, tables)
+            code_table = self.categorical_filter.autojoin_filter(code_table, tables)
         return code_table
 
     def _perform_time_filtering(self, code_table):

--- a/phenex/phenotypes/continuous_coverage_phenotype.py
+++ b/phenex/phenotypes/continuous_coverage_phenotype.py
@@ -1,5 +1,5 @@
 from typing import Union, List, Dict, Optional
-from phenex.mappers import ObservationPeriodTableMapper
+from phenex.tables import PhenexObservationPeriodTable
 from phenex.phenotypes.phenotype import Phenotype
 from phenex.filters.value import GreaterThanOrEqualTo, Value
 from phenex.filters.codelist_filter import CodelistFilter
@@ -26,7 +26,7 @@ class ContinuousCoveragePhenotype(Phenotype):
         2. Determine the date of loss to followup (right censoring) i.e. the duration of coverage after the anchor_phenotype event
 
     ## Data for ContinuousCoveragePhenotype
-    This phenotype requires a table with PersonID and a coverage start date and end date. Depending on the datasource used, this information is a separate ObservationPeriod table or found in the PersonTable. Use an ObservationPeriodTableMapper to map required coverage start and end date columns.
+    This phenotype requires a table with PersonID and a coverage start date and end date. Depending on the datasource used, this information is a separate ObservationPeriod table or found in the PersonTable. Use an PhenexObservationPeriodTable to map required coverage start and end date columns.
 
     | PersonID    |   coverageStartDate  |   coverageEndDate  |
     |-------------|----------------------|--------------------|

--- a/phenex/phenotypes/functions.py
+++ b/phenex/phenotypes/functions.py
@@ -1,6 +1,7 @@
 from typing import List
 from ibis.expr.types.relations import Table
 import ibis
+from phenex.tables import PhenexTable
 
 
 def hstack(phenotypes: List["Phenotype"], join_table: Table = None) -> Table:
@@ -10,6 +11,9 @@ def hstack(phenotypes: List["Phenotype"], join_table: Table = None) -> Table:
     Args:
         phenotypes (List[Phenotype]): A list of Phenotype objects to stack.
     """
+    # TODO decide if phenotypes should be returning a phenextable
+    if isinstance(join_table, PhenexTable):
+        join_table = join_table.table
     idx_phenotype_to_begin = 0
     join_type = "left" # if join table is defined, we want to left join
     if join_table is None:

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -60,6 +60,9 @@ class PhenexTable:
         # pass all attributes on to underlying table
         return getattr(self._table, name)
 
+    def __getitem__(self, key):
+        return self._table[key]
+
     @property
     def REQUIRED_FIELDS(self):
         return list(self.DEFAULT_MAPPING.keys())

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -60,9 +60,9 @@ class PhenexTable:
         # pass all attributes on to underlying table
         return getattr(self._table, name)
 
-    @classmethod
-    def REQUIRED_FIELDS(cls):
-        return list(cls.DEFAULT_MAPPING.keys())
+    @property
+    def REQUIRED_FIELDS(self):
+        return list(self.DEFAULT_MAPPING.keys())
 
     @property
     def table(self):
@@ -240,13 +240,13 @@ class PhenotypeTable(PhenexTable):
     KNOWN_FIELDS = [
         'PERSON_ID',
         'BOOLEAN',
-        'DATE',
+        'EVENT_DATE',
         'VALUE'
     ]
     DEFAULT_MAPPING = {
         'PERSON_ID': "PERSON_ID",
         "BOOLEAN": "BOOLEAN",
-        "DATE": "DATE",
+        "EVENT_DATE": "EVENT_DATE",
         "VALUE": "VALUE"
     }
 
@@ -256,13 +256,14 @@ def is_phenex_person_table(table: PhenexTable) -> bool:
     Check if given table is a person table.
     One could check one row per patient?
     """
-    return set(table.columns) >= set(PhenexPersonTable.REQUIRED_FIELDS)
-
+    return True
 
 def is_phenex_code_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
+    return True
+
     return set(table.columns) >= set(CodeTable.REQUIRED_FIELDS)
 
 
@@ -270,6 +271,8 @@ def is_phenex_event_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
+    return True
+
     return set(table.columns) >= set(EventTable.REQUIRED_FIELDS)
 
 
@@ -277,6 +280,8 @@ def is_phenex_phenotype_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
+    return True
+
     return set(table.columns) >= set(PhenotypeTable.REQUIRED_FIELDS)
 
 
@@ -284,7 +289,9 @@ def is_phenex_index_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
+    return True
+
     return isinstance(table, PhenexIndexTable)
 
 
-PHENOTYPE_TABLE_COLUMNS = PhenotypeTable.REQUIRED_FIELDS
+PHENOTYPE_TABLE_COLUMNS = ["PERSON_ID", "BOOLEAN", "EVENT_DATE", "VALUE"]

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -21,6 +21,7 @@ class PhenexTable:
     KNOWN_FIELDS = [] # List[phenex column names]
     DEFAULT_MAPPING = {} # dict: input column name -> phenex column name
     PATHS = {} # dict: table class name -> List[other table class names]
+    REQUIRED_FIELDS = list(DEFAULT_MAPPING.keys())
 
     def __init__(self, table, name=None, column_mapping={}):
         '''
@@ -61,10 +62,6 @@ class PhenexTable:
 
     def __getitem__(self, key):
         return self._table[key]
-
-    @property
-    def REQUIRED_FIELDS(self):
-        return list(self.DEFAULT_MAPPING.keys())
 
     @property
     def table(self):
@@ -260,14 +257,13 @@ def is_phenex_person_table(table: PhenexTable) -> bool:
     Check if given table is a person table.
     One could check one row per patient?
     """
-    return True
+    return set(table.columns) >= set(PhenexPersonTable.REQUIRED_FIELDS)
+
 
 def is_phenex_code_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return True
-
     return set(table.columns) >= set(CodeTable.REQUIRED_FIELDS)
 
 
@@ -275,8 +271,6 @@ def is_phenex_event_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return True
-
     return set(table.columns) >= set(EventTable.REQUIRED_FIELDS)
 
 
@@ -284,8 +278,6 @@ def is_phenex_phenotype_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return True
-
     return set(table.columns) >= set(PhenotypeTable.REQUIRED_FIELDS)
 
 
@@ -293,9 +285,7 @@ def is_phenex_index_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return True
-
-    return isinstance(table, PhenexIndexTable)
+    return set(table.columns) >= set(PhenexIndexTable.REQUIRED_FIELDS)
 
 
 PHENOTYPE_TABLE_COLUMNS = ["PERSON_ID", "BOOLEAN", "EVENT_DATE", "VALUE"]

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -1,74 +1,277 @@
 from ibis.expr.types.relations import Table
 
+from typing import Union
+import ibis 
+from ibis.expr.types.relations import Table
+import copy
 
-class PersonTable(Table):
-    # These datatpyes are just used for type hinting
-    pass
+class PhenexTable:
+    """
+    Phenex provides certain table types on which it knows how to operate. For instance, Phenex implements a CodeTable, which is an event table containing codes. Phenex has abstracted operations for each table type. For instance, given a CodeTable, Phenex knows how to filter this table based on the presence of codes within that table. Phenex doesn't care if the code table is actually a diagnosis code table or a procedure code table or a medication code table. 
+    
+    In onboarding a new data model to Phenex, the tables must be mapped into Phenex table types by subclassing the appropriate PhenexTable. When subclassing a PhenexTable, you must define:
+    
+        1. COLUMN_MAPPING: a mapping of the input table columns to the fields on the chosen PhenexTable type (e.g. 'CD' maps to 'CODE' in a CodeTable).
+        2. JOIN_KEYS: if you want to use the autojoin functionality of PhenexTable, you must specify what keys to use to join pairs of tables
+        3. PATHS: if you want to use the autojoin functionality of PhenexTable for more complex joins, you must specify join paths to take to get from one table to another    
+
+    Note that for each table type, there are REQUIRED_FIELDS, i.e., fields that MUST be defined for Phenex to work with such a table and KNOWN_FIELDS, i.e., fields that Phenex internally understands what to do with (there is a Phenotype that knows how to work with that field). For instance, in a PhenexPersonTable, one MUST define PERSON_ID, but DATE_OF_BIRTH is an optional field that PhenEx can process if given and transform into AGE. These are fixed for each table type and should not be overridden.
+    """
+    NAME_TABLE = 'PHENEX_TABLE' # name of table in the database
+    JOIN_KEYS = {} # dict: class name -> List[phenex column names]
+    KNOWN_FIELDS = [] # List[phenex column names]
+    DEFAULT_MAPPING = {} # dict: input column name -> phenex column name
+    PATHS = {} # dict: table class name -> List[other table class names]
+    
+    def __init__(self, table, name=None, column_mapping={}):
+        '''
+        Instantiate a PhenexTable, possibly overriding NAME_TABLE and COLUMN_MAPPING.
+        '''
+
+        if not isinstance(table, Table):
+            raise TypeError(f"Cannot instantiatiate {self.__class__.__name__} from {type(table)}. Must be ibis Table.")
+
+        self.NAME_TABLE = name or self.NAME_TABLE
+
+        self.column_mapping = self._get_column_mapping(column_mapping)
+        self._table = table.mutate(**self.column_mapping)
+
+        for key in self.REQUIRED_FIELDS:
+            try:
+                getattr(self._table, key)
+            except AttributeError:
+                raise ValueError(f"Required field {key} not defined in COLUMN_MAPPING.")
+
+        self._add_phenotype_table_relationship()
+
+    def _add_phenotype_table_relationship(self):
+        self.JOIN_KEYS['PhenotypeTable'] = ['PERSON_ID']
+
+    def _get_column_mapping(self, column_mapping=None):
+        column_mapping = column_mapping or {}
+        for key in column_mapping.keys():
+            if key not in self.KNOWN_FIELDS:
+                raise ValueError(f"Unknown mapped field {key} --> {column_mapping[key]} for f{type(self)}.")
+        default_mapping = copy.deepcopy(self.DEFAULT_MAPPING)
+        default_mapping.update(column_mapping)
+        return default_mapping
+        
+    def __getattr__(self, name):
+        # pass all attributes on to underlying table
+        return getattr(self._table, name)
+
+    @classmethod
+    def REQUIRED_FIELDS(cls):
+        return list(cls.DEFAULT_MAPPING.keys())
+    
+    @property
+    def table(self):
+        return self._table
+
+    def join(self, other: 'PhenexTable', *args, domains = None, **kwargs):
+        """
+        The join method performs a join of PhenexTables, using autojoin functionality if Phenex is able to find the table types specified in PATHS.
+        """
+        if not isinstance(other, PhenexTable):
+            raise TypeError(f"Expected a PhenexTable instance, got {type(other)}")
+        if len(args):
+            # if user specifies join keys and join type, simply perform join as specified
+            return type(self)(self.table.join(other.table, *args, **kwargs))
+
+        # Do an autojoin by finding a path from the left to the right table and sequentially joining as necessary            
+        joined_table = current_table = self        
+        for next_table_class_name in self._find_path(other):
+            next_table = [v for k,v in domains.items() if v.__class__.__name__ == next_table_class_name]
+            if len(next_table) != 1:
+                raise ValueError(f"Unable to find unqiue {next_table_class_name} required to join {other.__class__.__name__}")
+
+            next_table = next_table[0]
+            print(f"Joining : {current_table.__class__.__name__} to {next_table.__class__.__name__}")
+
+            # join keys are defined by the left table; in theory should enforce symmetry
+            join_keys = current_table.JOIN_KEYS[next_table_class_name] 
+            columns = list(set(joined_table.columns + next_table.columns))
+            joined_table = joined_table.join(next_table, join_keys, **kwargs).select(columns)
+            current_table = next_table
+        
+        return joined_table
+
+        
+    def _find_path(self, other):
+
+        start_name = self.__class__.__name__
+        end_name = other.__class__.__name__
+        # first see if direct connection
+        try:
+            self.JOIN_KEYS[end_name]
+            return [end_name]
+        except KeyError:
+            try:
+                return self.PATHS[end_name] + [end_name]
+            except KeyError:
+                raise ValueError(f'Cannot autojoin {start_name} --> {end_name}. Please specify join path in PATHS.')
+
+    def select(self, *args, **kwargs):
+        return type(self)(self.table.select(*args, **kwargs), name=self.NAME_TABLE)
+    
+    def filter(self, expr):
+        '''
+        Filter the table by an Ibis Expression or using a PhenExFilter.
+        '''
+        input_columns = self.columns
+        if isinstance(expr, ibis.expr.types.Expr):
+            filtered_table = self.table.filter(expr)
+        else:
+            filtered_table = expr.filter(self)
+            
+        return type(self)(
+            filtered_table.select(input_columns), 
+            name=self.NAME_TABLE, 
+            column_mapping=self.column_mapping)
+    
+
+class PhenexPersonTable(PhenexTable):
+    
+    NAME_TABLE = 'PERSON'
+    JOIN_KEYS = {
+        'CodeTable': ['PERSON_ID'],
+        'PhenexVisitDetailTable': ['PERSON_ID']
+    }
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'DATE_OF_BIRTH', 
+        'YEAR_OF_BIRTH', 
+        'DATE_OF_DEATH',
+        'SEX', 
+        'ETHNICITY'
+    ]
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID"
+    }
+
+class EventTable(PhenexTable):
+    
+    NAME_TABLE = 'EVENT'
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'EVENT_DATE'
+    ]
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "EVENT_DATE",
+    }
+
+class CodeTable(PhenexTable):
+    
+    NAME_TABLE = 'CODE'
+    RELATIONSHIPS = {
+        'PhenexPersonTable': ['PERSON_ID'],
+        'PhenexVisitDetailTable': ['PERSON_ID', 'VISIT_DETAIL_ID'],
+    }
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'EVENT_DATE', 
+        'CODE',
+        'CODE_TYPE',
+        'VISIT_DETAIL_ID'
+    ]
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        'EVENT_DATE': "EVENT_DATE",
+        'CODE': "CODE",
+    }
+
+class PhenexVisitDetailTable(PhenexTable):
+    
+    NAME_TABLE = 'VISIT_DETAIL'
+    RELATIONSHIPS = {
+        'PhenexPersonTable': ['PERSON_ID'],
+        'CodeTable': ['PERSON_ID', 'VISIT_DETAIL_ID'],
+    }
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'VISIT_DETAIL_ID',
+        'VISIT_DETAIL_SOURCE_VALUE',
+    ]
+    
+    DEFAULT_MAPPING = {
+        'PERSON_ID':'PERSON_ID',
+        'VISIT_DETAIL_ID': 'VISIT_DETAIL_ID',
+        'VISIT_DETAIL_SOURCE_VALUE': 'VISIT_DETAIL_SOURCE_VALUE'
+    }
 
 
-class IndexTable(Table):
-    # These datatpyes are just used for type hinting
-    pass
-
-
-class CodeTable(Table):
-    # These datatpyes are just used for type hinting
-    pass
-
-
-class EventTable(Table):
-    # These datatpyes are just used for type hinting
-    pass
-
+class PhenexIndexTable(PhenexTable):
+   
+    NAME_TABLE = 'INDEX'
+    JOIN_KEYS = {
+        'CodeTable': ['PERSON_ID'],
+        'PhenexVisitDetailTable': ['PERSON_ID']
+    }
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'INDEX_DATE',
+    ]
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        "INDEX_DATE": "INDEX_DATE"
+    }
 
 class MeasurementTable(Table):
     # These datatpyes are just used for type hinting
     pass
 
 
-class PhenotypeTable(Table):
-    # These datatpyes are just used for type hinting
-    pass
+class PhenotypeTable(PhenexTable):
+    NAME_TABLE = 'PHENOTYPE'
+    KNOWN_FIELDS = [
+        'PERSON_ID',
+        'BOOLEAN',
+        'DATE',
+        'VALUE'
+    ]
+    DEFAULT_MAPPING = {
+        'PERSON_ID': "PERSON_ID",
+        "BOOLEAN": "BOOLEAN",
+        "DATE": "DATE",
+        "VALUE": "VALUE"
+    }
 
 
-PERSON_TABLE_COLUMNS = ["PERSON_ID"]
-CODE_TABLE_COLUMNS = ["PERSON_ID", "EVENT_DATE", "CODE"]
-PHENOTYPE_TABLE_COLUMNS = ["PERSON_ID", "BOOLEAN", "EVENT_DATE", "VALUE"]
-EVENT_TABLE_COLUMNS = ["PERSON_ID", "EVENT_DATE"]
-INDEX_TABLE_COLUMNS = ["PERSON_ID", "INDEX_DATE"]
-
-
-def is_phenex_person_table(table: Table) -> bool:
+def is_phenex_person_table(table: PhenexTable) -> bool:
     """
     Check if given table is a person table.
     One could check one row per patient?
     """
-    return set(PERSON_TABLE_COLUMNS) <= set(table.columns)
+    return isinstance(table, PhenexPersonTable)
 
 
-def is_phenex_code_table(table: Table) -> bool:
+def is_phenex_code_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return set(CODE_TABLE_COLUMNS) <= set(table.columns + ["CODE_TYPE"])
+    return isinstance(table, CodeTable)
 
 
-def is_phenex_event_table(table: Table) -> bool:
+def is_phenex_event_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return set(EVENT_TABLE_COLUMNS) <= set(table.columns)
+    return isinstance(table, CodeTable)
 
 
-def is_phenex_phenotype_table(table: Table) -> bool:
+def is_phenex_phenotype_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return set(PHENOTYPE_TABLE_COLUMNS) <= set(table.columns)
+    return isinstance(table, PhenotypeTable)
 
 
-def is_phenex_index_table(table: Table) -> bool:
+def is_phenex_index_table(table: PhenexTable) -> bool:
     """
     Check if given table is a code table.
     """
-    return set(INDEX_TABLE_COLUMNS) <= set(table.columns)
+    return isinstance(table, PhenexIndexTable)
+
+
+PHENOTYPE_TABLE_COLUMNS = PhenotypeTable.REQUIRED_FIELDS

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -150,8 +150,7 @@ class PhenexPersonTable(PhenexTable):
         'ETHNICITY'
     ]
     DEFAULT_MAPPING = {
-        'PERSON_ID': "PERSON_ID",
-        'DATE_OF_BIRTH': 'DATE_OF_BIRTH'
+        'PERSON_ID': "PERSON_ID"
     }
 
 class EventTable(PhenexTable):

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -2,7 +2,6 @@ from ibis.expr.types.relations import Table
 
 from typing import Union
 import ibis
-from ibis.expr.types.relations import Table
 import copy
 
 class PhenexTable:
@@ -75,6 +74,9 @@ class PhenexTable:
         """
         The join method performs a join of PhenexTables, using autojoin functionality if Phenex is able to find the table types specified in PATHS.
         """
+        if isinstance(other, Table):
+            return type(self)(self.table.join(other, *args, **kwargs))
+
         if not isinstance(other, PhenexTable):
             raise TypeError(f"Expected a PhenexTable instance, got {type(other)}")
         if len(args):
@@ -96,7 +98,6 @@ class PhenexTable:
             columns = list(set(joined_table.columns + next_table.columns))
             joined_table = joined_table.join(next_table, join_keys, **kwargs).select(columns)
             current_table = next_table
-
         return joined_table
 
 
@@ -122,7 +123,7 @@ class PhenexTable:
         Filter the table by an Ibis Expression or using a PhenExFilter.
         '''
         input_columns = self.columns
-        if isinstance(expr, ibis.expr.types.Expr):
+        if isinstance(expr, ibis.expr.types.Expr) or isinstance(expr, list):
             filtered_table = self.table.filter(expr)
         else:
             filtered_table = expr.filter(self)

--- a/phenex/tables.py
+++ b/phenex/tables.py
@@ -150,7 +150,8 @@ class PhenexPersonTable(PhenexTable):
         'ETHNICITY'
     ]
     DEFAULT_MAPPING = {
-        'PERSON_ID': "PERSON_ID"
+        'PERSON_ID': "PERSON_ID",
+        'DATE_OF_BIRTH': 'DATE_OF_BIRTH'
     }
 
 class EventTable(PhenexTable):

--- a/phenex/test/phenotype_test_generator.py
+++ b/phenex/test/phenotype_test_generator.py
@@ -128,7 +128,6 @@ class PhenotypeTestGenerator:
             # data may have to be in a different format. It's best to keep your
             # seed data dates in pandas datetime format and let the
             # TestGenerator format them into strings.
-            print(path)
             df.to_csv(path, index=False, date_format=self.date_format)
 
             result_table = test_info["phenotype"].execute(self.domains)

--- a/phenex/test/phenotype_test_generator.py
+++ b/phenex/test/phenotype_test_generator.py
@@ -9,7 +9,7 @@ from pyarrow import int8
 from .util.check_equality import check_equality
 
 import logging
-
+from phenex.tables import *
 
 class PhenotypeTestGenerator:
     """
@@ -81,9 +81,19 @@ class PhenotypeTestGenerator:
                 else:
                     schema[col] = str
 
-            self.domains[input_info["name"]] = self.con.create_table(
+            table = self.con.create_table(
                 input_info["name"], input_info["df"], schema=schema
             )
+            if 'type' in input_info.keys():
+                table_type = input_info['type']
+            else:
+                table_type = PhenexTable
+                if input_info['name'].lower() in ['condition_occurrence', 'measurement']:
+                    table_type = CodeTable
+                elif input_info['name'].lower() in ['person']:
+                    table_type = PhenexPersonTable
+
+            self.domains[input_info["name"]] = table_type(table)
 
     def _run_tests(self):
         def df_from_test_info(test_info):


### PR DESCRIPTION
Newly added 
1. ColumnMappers have been renamed to PhenexTables and are now not only responsible for mapping database specific column names but also for join keys to directly joined tables and paths to indirectly joined tables.
2. Autojoin within the PhenexTable : uses join keys and paths to allow joining of tables that are not directly connected
3. Updates to CodelistPhenotype to implement codelist phenotype
4. New tests to CodelistPhenotype to test categorical filtering capability
5. Demo notebooks have updated import statements and fixes