### PR TITLE
updated exclusion chaining

### DIFF
--- a/phenex/reporting/waterfall.py
+++ b/phenex/reporting/waterfall.py
@@ -67,9 +67,7 @@ class Waterfall(Reporter):
                 phenotype.table, table["PERSON_ID"] == phenotype.table["PERSON_ID"]
             )
         elif type == "exclusion":
-            table = table.filter(
-                ~table["PERSON_ID"].isin(phenotype.table["PERSON_ID"])
-            )
+            table = table.filter(~table["PERSON_ID"].isin(phenotype.table["PERSON_ID"]))
         else:
             raise ValueError("type must be either inclusion or exclusion")
         logger.debug(f"Starting {type} criteria {phenotype.name}")

--- a/phenex/reporting/waterfall.py
+++ b/phenex/reporting/waterfall.py
@@ -67,8 +67,8 @@ class Waterfall(Reporter):
                 phenotype.table, table["PERSON_ID"] == phenotype.table["PERSON_ID"]
             )
         elif type == "exclusion":
-            table = table.anti_join(
-                phenotype.table, table["PERSON_ID"] == phenotype.table["PERSON_ID"]
+            table = table.filter(
+                ~table["PERSON_ID"].isin(phenotype.table["PERSON_ID"])
             )
         else:
             raise ValueError("type must be either inclusion or exclusion")


### PR DESCRIPTION
there was a problem with multiple exclusion phentypes. apparently ibis does not support sequential (chaining) of anti-joins. reimplemented joining of exclusion phenotype tables.