### PR TITLE
Harmonizebackends

### DIFF
--- a/phenex/phenotypes/__init__.py
+++ b/phenex/phenotypes/__init__.py
@@ -13,6 +13,7 @@ from .computation_graph_phenotypes import (
     ArithmeticPhenotype,
     LogicPhenotype,
 )
+from .within_same_encounter_phenotype import WithinSameEncounterPhenotype
 from .cohort import Cohort
 
 # from .age_phenotype import AgePhenotype

--- a/phenex/phenotypes/cohort.py
+++ b/phenex/phenotypes/cohort.py
@@ -19,6 +19,7 @@ def subset_and_add_index_date(tables: Dict[str, Table], index_table: PhenotypeTa
         subset_tables[key] = type(table)(
             table.inner_join(index_table, "PERSON_ID").select(columns)
         )
+    subset_tables["__INDEX"] = PhenotypeTable(index_table)
     return subset_tables
 
 

--- a/phenex/phenotypes/computation_graph_phenotypes.py
+++ b/phenex/phenotypes/computation_graph_phenotypes.py
@@ -75,7 +75,12 @@ class ComputationGraphPhenotype(Phenotype):
         Returns:
             PhenotypeTable: The resulting phenotype table containing the required columns.
         """
-        joined_table = hstack(self.children, tables["PERSON"].select("PERSON_ID"))
+        # in order to ensure table is created in the same backend (destination vs source), check of subset index tables exist. If no __INDEX table exists we use the source database PERSON table; this will result in the phenotype table being created in the source database rather than the destination database, which may cause errors.
+        index_table = (
+            tables["__INDEX"] if "__INDEX" in tables.keys() else tables["PERSON"]
+        )
+        index_table = index_table.select("PERSON_ID")
+        joined_table = hstack(self.children, index_table)
 
         if self.populate == "value" and self.operate_on == "boolean":
             for child in self.children:

--- a/phenex/phenotypes/within_same_encounter_phenotype.py
+++ b/phenex/phenotypes/within_same_encounter_phenotype.py
@@ -1,0 +1,41 @@
+from typing import Union
+from phenex.phenotypes.phenotype import Phenotype
+
+
+class WithinSameEncounterPhenotype(Phenotype):
+    def __init__(
+        self,
+        name: str,
+        anchor_phenotype: Union["CodelistPhenotype", "MeasurementPhenotype"],
+        phenotype: Union["CodelistPhenotype", "MeasurementPhenotype"],
+        column_name: str,
+        **kwargs,
+    ):
+        super(WithinSameEncounterPhenotype, self).__init__(**kwargs)
+        self.name = name
+        self.anchor_phenotype = anchor_phenotype
+        self.phenotype = phenotype
+        self.column_name = column_name
+        self.children.append(self.anchor_phenotype)
+
+    def _execute(self, tables) -> "PhenotypeTable":
+        # Subset the raw anchor data that occurs on the same day as the anchor date in order to get the column of interest
+        _anchor_table = tables[self.anchor_phenotype.domain]
+        _anchor_table = _anchor_table.join(
+            self.anchor_phenotype.table,
+            (self.anchor_phenotype.table.PERSON_ID == _anchor_table.PERSON_ID)
+            & (self.anchor_phenotype.table.EVENT_DATE == _anchor_table.EVENT_DATE),
+            how="inner",
+        ).select(["PERSON_ID", self.column_name])
+
+        # Subset the target phenotype raw data for patient id and column name of interest
+        _table = tables[self.phenotype.domain]
+        _table = _table.join(
+            _anchor_table,
+            (_anchor_table.PERSON_ID == _table.PERSON_ID)
+            & (_anchor_table[self.column_name] == _table[self.column_name]),
+            how="inner",
+        )
+
+        # run the target phenotype on the subsetted data
+        return self.phenotype._execute({self.phenotype.domain: _table})

--- a/phenex/test/phenotypes/test_within_same_encounter_phenotype.py
+++ b/phenex/test/phenotypes/test_within_same_encounter_phenotype.py
@@ -1,0 +1,150 @@
+import datetime, os
+import pandas as pd
+
+from phenex.phenotypes import CodelistPhenotype, WithinSameEncounterPhenotype
+from phenex.codelists.codelists import Codelist
+from phenex.filters.relative_time_range_filter import RelativeTimeRangeFilter
+from phenex.test.phenotype_test_generator import PhenotypeTestGenerator
+from phenex.filters.value import *
+
+
+class WithinSameEncounterPhenotypeTestGenerator(PhenotypeTestGenerator):
+    name_space = "wsept"
+
+    def define_input_tables(self):
+        min_days = datetime.timedelta(days=90)
+        max_days = datetime.timedelta(days=180)
+        one_day = datetime.timedelta(days=1)
+        index_date = datetime.date(2022, 1, 1)
+
+        # pass  patient 0 : has proc1 + cond1 within same encounter, proc BEFORE index_date
+        # fail  patient 1 : has proc1 + cond1, NOT within same encounter
+        # fail  patient 2 : has proc2 + cond1, within same encounter
+        # fail  patient 3 : has proc1 + cond2, within same encounter
+        # fail  patient 4 : has proc2 + cond2, within same encounter
+        # fail  patient 5 : has proc1 + cond1, NOT within same encounter, cond1 encounter null
+        # fail  patient 6 : has proc1 + cond1, NOT within same encounter, proc1 encounter null
+        # fail  patient 7 : has proc1 + cond1, NOT within same encounter, proc1 encounter null
+        # p/f   patient 8 : has proc1 + cond1 within same encounter, proc AFTER index_date
+
+        df_proc = pd.DataFrame()
+        df_proc["PERSON_ID"] = [f"P{i}" for i in range(8)]
+        df_proc["CODE"] = ["p1", "p1", "p2", "p1", "p2", "p1", "p1", "p1"]
+        df_proc["VISIT_OCCURRENCE_ID"] = [
+            "v1",
+            "v2",
+            "v1",
+            "v1",
+            "v1",
+            "v1",
+            None,
+            "v1",
+        ]
+        df_proc["EVENT_DATE"] = [
+            index_date - one_day,
+            index_date - one_day,
+            index_date - one_day,
+            index_date,
+            index_date + one_day,
+            index_date + one_day,
+            index_date + one_day,
+            index_date + one_day,
+        ]
+
+        df_cond = pd.DataFrame()
+        df_cond["PERSON_ID"] = [f"P{i}" for i in range(8)]
+        df_cond["CODE"] = ["c1", "c1", "c1", "c2", "c2", "c1", "c1", "c1"]
+        df_cond["VISIT_OCCURRENCE_ID"] = [
+            "v1",
+            "v1",
+            "v1",
+            "v1",
+            "v1",
+            None,
+            "v1",
+            "v1",
+        ]
+        df_cond["EVENT_DATE"] = [index_date] * 8
+
+        return [
+            {"name": "CONDITION_OCCURRENCE", "df": df_cond},
+            {"name": "PROCEDURE_OCCURRENCE", "df": df_proc},
+        ]
+
+    def define_phenotype_tests(self):
+        cond = CodelistPhenotype(
+            name="condition", domain="CONDITION_OCCURRENCE", codelist=Codelist("c1")
+        )
+        proc = CodelistPhenotype(
+            name="procedure", domain="PROCEDURE_OCCURRENCE", codelist=Codelist("p1")
+        )
+
+        proc_on_cond_hospitalization = WithinSameEncounterPhenotype(
+            name="proc_on_cond",
+            anchor_phenotype=cond,
+            phenotype=proc,
+            column_name="VISIT_OCCURRENCE_ID",
+        )
+
+        t1 = {
+            "name": "proc_on_cond",
+            "persons": ["P0", "P7"],
+            "phenotype": proc_on_cond_hospitalization,
+        }
+
+        # Test with relative time range filter procedure must be PRIOR to index
+        proc_prior_index = CodelistPhenotype(
+            name="procedure_prior_index",
+            domain="PROCEDURE_OCCURRENCE",
+            codelist=Codelist("p1"),
+            relative_time_range=RelativeTimeRangeFilter(
+                min_days=GreaterThanOrEqualTo(0), when="before", anchor_phenotype=cond
+            ),
+        )
+
+        proc_on_cond_prior_index = WithinSameEncounterPhenotype(
+            name="proc_on_cond_prior_index",
+            anchor_phenotype=cond,
+            phenotype=proc_prior_index,
+            column_name="VISIT_OCCURRENCE_ID",
+        )
+
+        t2 = {
+            "name": "proc_on_cond",
+            "persons": ["P0"],
+            "phenotype": proc_on_cond_prior_index,
+        }
+
+        # Test with relative time range filter procedure must be POST to index
+        proc_post_index = CodelistPhenotype(
+            name="procedure_post_index",
+            domain="PROCEDURE_OCCURRENCE",
+            codelist=Codelist("p1"),
+            relative_time_range=RelativeTimeRangeFilter(
+                min_days=GreaterThanOrEqualTo(0), when="after", anchor_phenotype=cond
+            ),
+        )
+
+        proc_on_cond_post_index = WithinSameEncounterPhenotype(
+            name="proc_on_cond_post_index",
+            anchor_phenotype=cond,
+            phenotype=proc_post_index,
+            column_name="VISIT_OCCURRENCE_ID",
+        )
+
+        t3 = {
+            "name": "proc_on_cond_post_index",
+            "persons": ["P7"],
+            "phenotype": proc_on_cond_post_index,
+        }
+
+        return [t1, t2, t3]
+
+
+def test_within_same_encounter_phenotype():
+    tg = WithinSameEncounterPhenotypeTestGenerator()
+    tg.run_tests()
+
+
+if __name__ == "__main__":
+    test_within_same_encounter_phenotype()


### PR DESCRIPTION
There was an issue, which resulted in errors in the Waterfall reporter, with multiple backends. This would appear when using a LogicPhenotype, which uses the hstack function, as the initial list of patient ids was coming from the domains["PERSON_ID"] table. This resulted in the entire LogicPhenotype (and therefore all ComputationGraphPhenotypes, Score, Arithmetic, Logic) output using the source backend, when it should be the destination backend. The cohort now includes the index_table in the subset_tables domains dictionary, which can then be used by the ComputationGraphPhenotypes, solving this issue.