### PR TITLE
value filter for ccpt

### DIFF
--- a/phenex/phenotypes/continuous_coverage_phenotype.py
+++ b/phenex/phenotypes/continuous_coverage_phenotype.py
@@ -1,15 +1,11 @@
 from typing import Union, List, Dict, Optional
-from phenex.tables import PhenexObservationPeriodTable
 from phenex.phenotypes.phenotype import Phenotype
-from phenex.filters.value import GreaterThanOrEqualTo, Value
-from phenex.filters.codelist_filter import CodelistFilter
+from phenex.filters.value import GreaterThanOrEqualTo
 from phenex.filters.relative_time_range_filter import (
     verify_relative_time_range_filter_input,
     RelativeTimeRangeFilter,
 )
-from phenex.filters.date_filter import DateFilter
-from phenex.aggregators import First, Last
-from phenex.codelists import Codelist
+from phenex.filters.date_filter import ValueFilter
 from phenex.tables import is_phenex_code_table, PHENOTYPE_TABLE_COLUMNS, PhenotypeTable
 from phenex.phenotypes.functions import select_phenotype_columns
 from ibis import _
@@ -35,52 +31,52 @@ class ContinuousCoveragePhenotype(Phenotype):
 
     One assumption that is made by ContinuousCoveragePhenotype is that there are **NO overlapping coverage periods**.
 
+    Parameters:
+        name: The name of the phenotype.
+        domain: The domain of the phenotype. Default is 'observation_period'.
+        value_filter: Fitler returned persons based on the duration of coverage in days.
+        anchor_phenotype: An anchor phenotype defines the reference date with respect to calculate coverage. In typical applications, the anchor phenotype will be the entry criterion.
+        when: 'before', 'after'. If before, the return date is the start of the coverage period containing the anchor_phenotype. If after, the return date is the end of the coverage period containing the anchor_phenotype.
+
+    Example:
+    ```python
+    # make sure to create an entry phenotype, for example 'atrial fibrillation diagnosis'
+    entry_phenotype = CodelistPhenotype(...)
+    # one year continuous coverage prior to index
+    one_year_coverage = ContinuousCoveragePhenotype(
+        when = 'before',
+        value_filter = ValueFilter(
+            min_value=GreaterThanOrEqualTo(365)
+            ),
+        anchor_phenotype = entry_phenotype
+    )
+    # determine the date of loss to followup
+    loss_to_followup = ContinuousCoveragePhenotype(
+        when = 'after',
+        anchor_phenotype = entry_phenotype
+    )
+    ```
     """
 
     def __init__(
         self,
         name: Optional[str] = "continuous_coverage",
         domain: Optional[str] = "OBSERVATION_PERIOD",
-        min_days: Optional[Value] = None,
-        max_days: Optional[Value] = None,
+        value_filter: Optional[ValueFilter] = None,
         when: Optional[str] = "before",
         anchor_phenotype: Optional[Phenotype] = None,
         **kwargs
     ):
-        """
-        Parameters:
-            name: The name of the phenotype. Default is provided by parameters when, min_days, max_days, and anchor_phenotype.
-            domain: The domain of the phenotype. Default is 'observation_period'.
-            min_days: The minimum number of days of continuous coverage. The operator must be '>=' or '>'.
-            max_days: The maximum number of days of continuous coverage. The operator must be '<=' or '<'.
-            when: 'before', 'after'. If before, the return date is the start of the coverage period containing the anchor_phenotype. If after, the return date is the end of the coverage period containing the anchor_phenotype.
-        Example :
-        ```python
-
-        # make sure to create an entry phenotype, for example 'atrial fibrillation diagnosis'
-        entry_phenotype = CodelistPhenotype(...)
-
-        # one year continuous coverage prior to index
-        one_year_coverage = ContinuousCoveragePhenotype(
-            when = 'before',
-            min_days = GreaterThanOrEqualTo(365),
-            anchor_phenotype = entry_phenotype
-        )
-
-        # determine the date of loss to followup
-        loss_to_followup = ContinuousCoveragePhenotype(
-            when = 'after',
-            anchor_phenotype = entry_phenotype
-        )
-        ```
-        """
         super().__init__(**kwargs)
         self.name = name
         self.domain = domain
-        verify_relative_time_range_filter_input(min_days, max_days, when)
-        self.min_days = min_days
-        self.max_days = max_days
         self.when = when
+        self.min_days = self.max_days = None
+        if value_filter:
+            self.min_days = value_filter.min_value
+            self.max_days = value_filter.max_value
+
+        verify_relative_time_range_filter_input(self.min_days, self.max_days, self.when)
         self.anchor_phenotype = anchor_phenotype
         if self.anchor_phenotype is not None:
             self.children.append(self.anchor_phenotype)

--- a/phenex/test/cohort/test_cohort_various_phenotypes_as_inex.py
+++ b/phenex/test/cohort/test_cohort_various_phenotypes_as_inex.py
@@ -47,7 +47,7 @@ class CohortWithContinuousCoverageTestGenerator(CohortTestGenerator):
         )
 
         cc = ContinuousCoveragePhenotype(
-            min_days=GreaterThanOrEqualTo(365),
+            value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(365))
         )
 
         return Cohort(
@@ -169,7 +169,7 @@ class CohortWithContinuousCoverageAndExclusionTestGenerator(CohortTestGenerator)
         )
 
         cc = ContinuousCoveragePhenotype(
-            min_days=GreaterThanOrEqualTo(365),
+            value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(365))
         )
 
         e4 = CodelistPhenotype(
@@ -325,7 +325,7 @@ class CohortWithContinuousCoverageExclusionAndAgeTestGenerator(CohortTestGenerat
         )
 
         cc = ContinuousCoveragePhenotype(
-            min_days=GreaterThanOrEqualTo(365),
+            value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(365))
         )
         agege18 = AgePhenotype(
             value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(18))
@@ -452,7 +452,7 @@ class CohortWithContinuousCoverageExclusionAndAgeAsExclusionTestGenerator(
         )
 
         cc = ContinuousCoveragePhenotype(
-            min_days=GreaterThanOrEqualTo(365),
+            value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(365))
         )
         agel18 = AgePhenotype(value_filter=ValueFilter(max_value=LessThan(18)))
 
@@ -579,7 +579,7 @@ class CohortWithContinuousCoverageExclusionAgeSexTestGenerator(CohortTestGenerat
         )
 
         cc = ContinuousCoveragePhenotype(
-            min_days=GreaterThanOrEqualTo(365),
+            value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(365))
         )
         agege18 = AgePhenotype(
             value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(18))

--- a/phenex/test/cohort/test_cprd_endocrine_therapy_cohort_with_dummy_data.py
+++ b/phenex/test/cohort/test_cprd_endocrine_therapy_cohort_with_dummy_data.py
@@ -64,7 +64,8 @@ def create_cohort():
 
 def define_inclusion_exclusion_criteria(entry):
     continuous_coverage = ContinuousCoveragePhenotype(
-        min_days=GreaterThanOrEqualTo(365), anchor_phenotype=entry
+        value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(365)),
+        anchor_phenotype=entry,
     )
 
     age_18 = AgePhenotype(

--- a/phenex/test/phenotypes/test_continuous_coverage_phenotype.py
+++ b/phenex/test/phenotypes/test_continuous_coverage_phenotype.py
@@ -3,9 +3,8 @@ import pandas as pd
 
 from phenex.phenotypes.continuous_coverage_phenotype import ContinuousCoveragePhenotype
 from phenex.phenotypes.codelist_phenotype import CodelistPhenotype
-from phenex.codelists import LocalCSVCodelistFactory, Codelist
-from phenex.filters.date_filter import DateFilter
-from phenex.filters.relative_time_range_filter import RelativeTimeRangeFilter
+from phenex.codelists import Codelist
+from phenex.filters import ValueFilter
 
 from phenex.test.phenotype_test_generator import PhenotypeTestGenerator
 from phenex.filters.value import *
@@ -80,7 +79,9 @@ class ContinuousCoveragePhenotypeTestGenerator(PhenotypeTestGenerator):
         for test_info in test_infos:
             test_info["phenotype"] = ContinuousCoveragePhenotype(
                 name=test_info["name"],
-                min_days=test_info.get("coverage_period_min"),
+                value_filter=ValueFilter(
+                    min_value=test_info.get("coverage_period_min")
+                ),
             )
 
         return test_infos
@@ -122,7 +123,9 @@ class ContinuousCoverageReturnLastPhenotypeTestGenerator(
         for test_info in test_infos:
             test_info["phenotype"] = ContinuousCoveragePhenotype(
                 name=test_info["name"],
-                min_days=test_info.get("coverage_period_min"),
+                value_filter=ValueFilter(
+                    min_value=test_info.get("coverage_period_min")
+                ),
                 when="after",
             )
 
@@ -156,7 +159,7 @@ class ContinuousCoverageWithAnchorPhenotype(ContinuousCoveragePhenotypeTestGener
 
         cc1 = ContinuousCoveragePhenotype(
             name="cc_prior_entry",
-            min_days=GreaterThanOrEqualTo(90),
+            value_filter=ValueFilter(min_value=GreaterThanOrEqualTo(90)),
             when="before",
             anchor_phenotype=entry,
         )


### PR DESCRIPTION
In order to make the interface for phenotypes more consistent, ContinuousCoveragePhenotype should take value_filter instead of min_days / max_days