### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/Codelist Management.md
+++ b/.codeboarding/Codelist Management.md
@@ -1,0 +1,67 @@
+```mermaid
+graph LR
+    Codelist["Codelist"]
+    LocalCSVCodelistFactory["LocalCSVCodelistFactory"]
+    MedConBCodelistFactory["MedConBCodelistFactory"]
+    SerializationUtility["SerializationUtility"]
+    LocalCSVCodelistFactory -- "creates" --> Codelist
+    MedConBCodelistFactory -- "creates" --> Codelist
+    Codelist -- "uses" --> SerializationUtility
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Codelist Management subsystem provides a robust framework for defining, loading, and manipulating medical codelists from various external sources. It centers around the `Codelist` component, which serves as the core data structure for representing medical concepts and their associated codes. Factory components like `LocalCSVCodelistFactory` and `MedConBCodelistFactory` are responsible for creating `Codelist` instances from specific data formats and external systems, respectively. The `SerializationUtility` component assists in converting `Codelist` objects into dictionary formats for various purposes.
+
+### Codelist
+The Codelist component is a core data structure for managing medical codes. It allows for the representation of a single medical concept with associated codes from various vocabularies. It provides methods for initialization from different data formats (YAML, Excel, CSV, MedConB), copying, converting to pandas DataFrames or dictionaries, and performing set operations (union and difference) on codelists. It also handles fuzzy matching and punctuation removal for codes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L8-L458" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist` (8:458)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L174-L196" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:copy` (174:196)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L222-L252" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:from_yaml` (222:252)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L255-L333" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:from_excel` (255:333)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L336-L357" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:from_csv` (336:357)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L360-L381" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:from_medconb` (360:381)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L399-L406" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:to_pandas` (399:406)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L408-L409" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:to_dict` (408:409)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L411-L432" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:__add__` (411:432)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L434-L458" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist:__sub__` (434:458)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L383-L391" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.Codelist.to_tuples` (383:391)</a>
+
+
+### LocalCSVCodelistFactory
+The LocalCSVCodelistFactory component is responsible for creating Codelist instances from a single CSV file that contains multiple codelists. It provides methods to retrieve a list of all available codelists within the CSV and to retrieve a specific Codelist by its name.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L461-L524" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.LocalCSVCodelistFactory` (461:524)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L511-L524" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.LocalCSVCodelistFactory:get_codelist` (511:524)</a>
+
+
+### MedConBCodelistFactory
+The MedConBCodelistFactory component facilitates the retrieval of Codelists from the MedConB system. It interacts with a MedConB client to fetch codelists by ID and convert them into the PhenEx Codelist format.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L527-L564" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.MedConBCodelistFactory` (527:564)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L551-L556" target="_blank" rel="noopener noreferrer">`phenex.codelists.codelists.MedConBCodelistFactory:get_codelist` (551:556)</a>
+
+
+### SerializationUtility
+The SerializationUtility component provides a generic method for converting objects to dictionaries. In this context, it is used by the Codelist component to serialize its data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/to_dict.py#L5-L39" target="_blank" rel="noopener noreferrer">`phenex.util.serialization.to_dict.to_dict` (5:39)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Access Layer.md
+++ b/.codeboarding/Data Access Layer.md
@@ -1,0 +1,53 @@
+```mermaid
+graph LR
+    Database_Connectors["Database Connectors"]
+    Phenex_Table_Management["Phenex Table Management"]
+    Database_Connectors -- "provides data to" --> Phenex_Table_Management
+    Phenex_Table_Management -- "provides data for" --> Phenotype_Core
+    Phenotype_Core -- "produces" --> Phenex_Table_Management
+    Age_Phenotype -- "queries" --> Phenex_Table_Management
+    Death_Phenotype -- "queries" --> Phenex_Table_Management
+    Filtering_Logic -- "filters" --> Phenex_Table_Management
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Data Access Layer manages connections to various databases and provides an abstract representation of data tables for querying and manipulation within the PhenEx system. It is composed of database connectors for establishing and managing connections to different database types, and a table management component that defines and handles the various data table structures used throughout the application.
+
+### Database Connectors
+This component provides functionalities to establish and manage connections to various databases like Snowflake and DuckDB using the Ibis framework. It handles environment variable checks and connection pooling for both source and destination databases, allowing for data retrieval and materialization (creating views/tables).
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/ibis_connect.py#L25-L319" target="_blank" rel="noopener noreferrer">`phenex.ibis_connect.SnowflakeConnector` (25:319)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/ibis_connect.py#L322-L354" target="_blank" rel="noopener noreferrer">`phenex.ibis_connect.DuckDBConnector` (322:354)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/ibis_connect.py#L8-L22" target="_blank" rel="noopener noreferrer">`phenex.ibis_connect._check_env_vars` (8:22)</a>
+
+
+### Phenex Table Management
+This component defines abstract and concrete table types within the Phenex system, providing a standardized interface for data manipulation. It includes functionalities for column mapping, joining tables based on predefined keys and paths, and basic table operations like mutation and filtering, ensuring data consistency across different phenotype computations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L8-L152" target="_blank" rel="noopener noreferrer">`phenex.tables.PhenexTable` (8:152)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L155-L170" target="_blank" rel="noopener noreferrer">`phenex.tables.PhenexPersonTable` (155:170)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L183-L195" target="_blank" rel="noopener noreferrer">`phenex.tables.CodeTable` (183:195)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L173-L180" target="_blank" rel="noopener noreferrer">`phenex.tables.EventTable` (173:180)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L198-L214" target="_blank" rel="noopener noreferrer">`phenex.tables.PhenexVisitOccurrenceTable` (198:214)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L217-L227" target="_blank" rel="noopener noreferrer">`phenex.tables.PhenexIndexTable` (217:227)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L230-L241" target="_blank" rel="noopener noreferrer">`phenex.tables.PhenexObservationPeriodTable` (230:241)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L244-L263" target="_blank" rel="noopener noreferrer">`phenex.tables.MeasurementTable` (244:263)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L266-L274" target="_blank" rel="noopener noreferrer">`phenex.tables.PhenotypeTable` (266:274)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L277-L282" target="_blank" rel="noopener noreferrer">`phenex.tables.is_phenex_person_table` (277:282)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L285-L289" target="_blank" rel="noopener noreferrer">`phenex.tables.is_phenex_code_table` (285:289)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L292-L296" target="_blank" rel="noopener noreferrer">`phenex.tables.is_phenex_event_table` (292:296)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L299-L303" target="_blank" rel="noopener noreferrer">`phenex.tables.is_phenex_phenotype_table` (299:303)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L306-L310" target="_blank" rel="noopener noreferrer">`phenex.tables.is_phenex_index_table` (306:310)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Transformation & Utilities.md
+++ b/.codeboarding/Data Transformation & Utilities.md
@@ -1,0 +1,106 @@
+```mermaid
+graph LR
+    Aggregators["Aggregators"]
+    Phenotypes["Phenotypes"]
+    Filters["Filters"]
+    Serialization_Utilities["Serialization Utilities"]
+    Codelists["Codelists"]
+    Table_Utilities["Table Utilities"]
+    Aggregators -- "uses" --> Serialization_Utilities
+    Phenotypes -- "utilizes" --> Aggregators
+    Phenotypes -- "applies" --> Filters
+    Phenotypes -- "interacts with" --> Table_Utilities
+    Phenotypes -- "uses" --> Serialization_Utilities
+    Filters -- "uses" --> Serialization_Utilities
+    Codelists -- "uses" --> Serialization_Utilities
+    Serialization_Utilities -- "uses" --> Codelists
+    Serialization_Utilities -- "uses" --> Phenotypes
+    Serialization_Utilities -- "uses" --> Filters
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the structure and interactions within the Data Transformation & Utilities subsystem of PhenEx. It encompasses components responsible for data aggregation, filtering, serialization/deserialization of PhenEx objects, and managing phenotype definitions, codelists, and table utilities. The main flow involves phenotypes utilizing aggregators and filters to process data, with serialization utilities facilitating object persistence and exchange, and codelists and table utilities providing supporting data structures and validation.
+
+### Aggregators
+This component provides various strategies for aggregating data, including vertical date-based aggregations (like finding the first, last, or nearest date) and value-based aggregations (like mean, max, min, and daily variations).
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L7-L60" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.VerticalDateAggregator` (7:60)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L63-L65" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Nearest` (63:65)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L68-L70" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.First` (68:70)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L73-L75" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Last` (73:75)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L78-L137" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.ValueAggregator` (78:137)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L140-L142" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Mean` (140:142)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L145-L147" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Max` (145:147)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L150-L152" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Min` (150:152)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L155-L160" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyValueAggregator` (155:160)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L163-L165" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMean` (163:165)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L168-L170" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMedian` (168:170)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L173-L175" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMax` (173:175)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L178-L180" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMin` (178:180)</a>
+
+
+### Phenotypes
+This component defines the core phenotype logic, including specific implementations for categorical, measurement change, and codelist-based phenotypes. It also includes the base phenotype definition and computation graph management.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/categorical_phenotype.py#L51-L138" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.categorical_phenotype.HospitalizationPhenotype` (51:138)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/measurement_change_phenotype.py#L12-L161" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.measurement_change_phenotype.MeasurementChangePhenotype` (12:161)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/codelist_phenotype.py#L13-L178" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.codelist_phenotype.CodelistPhenotype` (13:178)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/phenotype.py#L15-L184" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.phenotype.Phenotype` (15:184)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/phenotype.py#L194-L346" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.phenotype.ComputationGraph` (194:346)</a>
+
+
+### Filters
+This component offers a flexible framework for filtering data based on various criteria, supporting logical operations (AND, OR, NOT) and specific value-based filtering.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L7-L62" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.Filter` (7:62)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L65-L80" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.AndFilter` (65:80)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L83-L100" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.OrFilter` (83:100)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L103-L117" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.NotFilter` (103:117)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/value.py#L6-L30" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.value.Value` (6:30)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/value_filter.py#L13-L71" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.value_filter.ValueFilter` (13:71)</a>
+
+
+### Serialization Utilities
+This component provides utility functions for converting PhenEx objects to and from dictionary representations, facilitating serialization (e.g., to JSON) and deserialization.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/to_dict.py#L5-L39" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.util.serialization.to_dict.to_dict` (5:39)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/to_dict.py#L42-L51" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.util.serialization.to_dict.get_phenex_init_params` (42:51)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/from_dict.py#L13-L58" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.util.serialization.from_dict.from_dict` (13:58)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/from_dict.py#L61-L72" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.util.serialization.from_dict.convert_null_keys_to_none_in_dictionary` (61:72)</a>
+
+
+### Codelists
+This component manages the definition and representation of codelists, which are used to categorize and group medical codes or other identifiers.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L8-L458" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.codelists.codelists.Codelist` (8:458)</a>
+
+
+### Table Utilities
+This component provides utility functions for interacting with data tables, specifically to determine if a given table is a PhenEx code table.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L285-L289" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.is_phenex_code_table` (285:289)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Phenotype Engine.md
+++ b/.codeboarding/Phenotype Engine.md
@@ -1,0 +1,140 @@
+```mermaid
+graph LR
+    Phenotype_Base["Phenotype Base"]
+    Computation_Graph["Computation Graph"]
+    Cohort_Definition["Cohort Definition"]
+    Specific_Phenotypes["Specific Phenotypes"]
+    Composite_Phenotypes["Composite Phenotypes"]
+    Phenotype_Factories["Phenotype Factories"]
+    Data_Serialization_Utilities["Data & Serialization Utilities"]
+    Filtering_Logic["Filtering Logic"]
+    Reporting_Module["Reporting Module"]
+    Phenotype_Base -- "is extended by" --> Specific_Phenotypes
+    Phenotype_Base -- "is extended by" --> Composite_Phenotypes
+    Phenotype_Base -- "creates" --> Computation_Graph
+    Phenotype_Base -- "uses" --> Data_Serialization_Utilities
+    Computation_Graph -- "processes" --> Phenotype_Base
+    Computation_Graph -- "uses" --> Data_Serialization_Utilities
+    Cohort_Definition -- "inherits from" --> Phenotype_Base
+    Cohort_Definition -- "uses" --> Data_Serialization_Utilities
+    Cohort_Definition -- "generates" --> Reporting_Module
+    Specific_Phenotypes -- "utilize" --> Filtering_Logic
+    Composite_Phenotypes -- "builds upon" --> Computation_Graph
+    Composite_Phenotypes -- "inherits from" --> Phenotype_Base
+    Phenotype_Factories -- "assembles" --> Specific_Phenotypes
+    Phenotype_Factories -- "assembles" --> Composite_Phenotypes
+    Phenotype_Factories -- "applies" --> Filtering_Logic
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Phenotype Engine defines the core logic for creating and executing phenotypes and managing patient cohorts based on defined criteria. It encompasses the foundational abstract phenotype definitions, mechanisms for building complex computational graphs, tools for cohort definition and management, and various specific and composite phenotype implementations. Additionally, it includes utilities for data handling, serialization, filtering, and reporting, providing a comprehensive framework for phenotypic analysis.
+
+### Phenotype Base
+The foundational component defining the abstract concept of a phenotype, its execution lifecycle, and basic properties. It serves as the parent for all specific phenotype implementations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/phenotype.py#L15-L184" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.phenotype.Phenotype` (15:184)</a>
+
+
+### Computation Graph
+Manages the representation and evaluation of complex arithmetic and logical operations between phenotypes, forming a directed acyclic graph (DAG) of computations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/phenotype.py#L194-L346" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.phenotype.ComputationGraph` (194:346)</a>
+
+
+### Cohort Definition
+Responsible for defining and executing cohorts, which involve combining multiple phenotypes to identify specific patient populations based on inclusion and exclusion criteria.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/cohort.py#L25-L359" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.cohort.Cohort` (25:359)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/cohort.py#L14-L22" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.cohort.subset_and_add_index_date` (14:22)</a>
+
+
+### Specific Phenotypes
+A broad category encompassing various concrete implementations of phenotypes, each designed to identify a particular clinical or demographic characteristic. These include codelist-based, categorical, measurement, and time-based phenotypes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/within_same_encounter_phenotype.py#L5-L100" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.within_same_encounter_phenotype.WithinSameEncounterPhenotype` (5:100)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/categorical_phenotype.py#L14-L48" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.categorical_phenotype.CategoricalPhenotype` (14:48)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/categorical_phenotype.py#L51-L138" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.categorical_phenotype.HospitalizationPhenotype` (51:138)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/measurement_phenotype.py#L12-L135" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.measurement_phenotype.MeasurementPhenotype` (12:135)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/continuous_coverage_phenotype.py#L11-L102" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.continuous_coverage_phenotype.ContinuousCoveragePhenotype` (11:102)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/age_phenotype.py#L15-L157" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.age_phenotype.AgePhenotype` (15:157)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/multiple_occurrences_phenotype.py#L9-L109" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.multiple_occurrences_phenotype.MultipleOccurrencesPhenotype` (9:109)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/sex_phenotype.py#L10-L43" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.sex_phenotype.SexPhenotype` (10:43)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/codelist_phenotype.py#L13-L178" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.codelist_phenotype.CodelistPhenotype` (13:178)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/death_phenotype.py#L9-L54" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.death_phenotype.DeathPhenotype` (9:54)</a>
+
+
+### Composite Phenotypes
+Phenotypes that are built upon ComputationGraph to perform arithmetic or logical operations on other phenotypes, enabling the creation of more complex definitions like scores or boolean combinations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/computation_graph_phenotypes.py#L10-L173" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.computation_graph_phenotypes.ComputationGraphPhenotype` (10:173)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/computation_graph_phenotypes.py#L176-L220" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.computation_graph_phenotypes.ScorePhenotype` (176:220)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/computation_graph_phenotypes.py#L223-L263" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.computation_graph_phenotypes.ArithmeticPhenotype` (223:263)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/computation_graph_phenotypes.py#L266-L295" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.computation_graph_phenotypes.LogicPhenotype` (266:295)</a>
+
+
+### Phenotype Factories
+Provides pre-packaged, complex phenotype definitions, often combining multiple simpler phenotypes and logical operations, to facilitate the creation of commonly used clinical definitions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/factory/isth_major_bleed.py#L44-L81" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.factory.isth_major_bleed.ISTHMajorBleedPhenotype` (44:81)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/factory/isth_major_bleed.py#L84-L115" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.factory.isth_major_bleed.CriticalOrganBleedPhenotype` (84:115)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/factory/isth_major_bleed.py#L118-L152" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.factory.isth_major_bleed.SymptomaticBleedPhenotype` (118:152)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/factory/isth_major_bleed.py#L155-L201" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.factory.isth_major_bleed.FatalBleedPhenotype` (155:201)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/factory/isth_major_bleed.py#L204-L239" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.factory.isth_major_bleed.BleedVerificationPhenotype` (204:239)</a>
+
+
+### Data & Serialization Utilities
+Contains utility functions for data table validation, manipulation (like horizontal stacking), and object serialization to dictionary format.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L299-L303" target="_blank" rel="noopener noreferrer">`phenex.tables.is_phenex_phenotype_table` (299:303)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/to_dict.py#L5-L39" target="_blank" rel="noopener noreferrer">`phenex.util.serialization.to_dict.to_dict` (5:39)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/functions.py#L28-L56" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.functions.hstack` (28:56)</a>
+
+
+### Filtering Logic
+Provides a set of reusable filter classes that define criteria for selecting or excluding data based on various attributes such as categories, codelists, time ranges, and value comparisons.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/categorical_filter.py#L5-L125" target="_blank" rel="noopener noreferrer">`phenex.filters.categorical_filter.CategoricalFilter` (5:125)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/relative_time_range_filter.py#L9-L100" target="_blank" rel="noopener noreferrer">`phenex.filters.relative_time_range_filter.RelativeTimeRangeFilter` (9:100)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/codelist_filter.py#L10-L83" target="_blank" rel="noopener noreferrer">`phenex.filters.codelist_filter.CodelistFilter` (10:83)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/value.py#L38-L40" target="_blank" rel="noopener noreferrer">`phenex.filters.value.GreaterThanOrEqualTo` (38:40)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/value.py#L48-L50" target="_blank" rel="noopener noreferrer">`phenex.filters.value.LessThanOrEqualTo` (48:50)</a>
+
+
+### Reporting Module
+Handles the generation of structured reports, such as summary tables, from processed phenotype and cohort data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L9-L115" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1` (9:115)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Reporting & Analytics.md
+++ b/.codeboarding/Reporting & Analytics.md
@@ -1,0 +1,77 @@
+```mermaid
+graph LR
+    Reporting_Analytics_Base["Reporting & Analytics Base"]
+    InExCounts_Module["InExCounts Module"]
+    Waterfall_Module["Waterfall Module"]
+    Table1_Module["Table1 Module"]
+    Cohort_Management_Module["Cohort Management Module"]
+    InExCounts_Module -- "is a type of" --> Reporting_Analytics_Base
+    Waterfall_Module -- "is a type of" --> Reporting_Analytics_Base
+    Table1_Module -- "is a type of" --> Reporting_Analytics_Base
+    Cohort_Management_Module -- "uses" --> Table1_Module
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Reporting & Analytics subsystem provides comprehensive tools for generating various reports, summaries, and visualizations from processed patient data and defined cohorts. It encompasses modules for calculating inclusion/exclusion counts, generating waterfall diagrams to track cohort attrition, and creating detailed 'Table 1' baseline characteristic reports. The system is designed to integrate with cohort management functionalities, allowing for direct reporting on defined patient groups.
+
+### Reporting & Analytics Base
+Provides a unified interface and base functionality for generating various types of reports, summaries, and visualizations from processed patient data and defined cohorts. It acts as a central hub for different reporting modules.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/reporter.py#L1-L13" target="_blank" rel="noopener noreferrer">`phenex.reporting.reporter.Reporter` (1:13)</a>
+
+
+### InExCounts Module
+This module is responsible for calculating and reporting the counts of patients satisfying specific inclusion and exclusion criteria. It provides methods to get counts for a list of phenotypes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/counts.py#L6-L35" target="_blank" rel="noopener noreferrer">`phenex.reporting.counts.InExCounts` (6:35)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/counts.py#L12-L20" target="_blank" rel="noopener noreferrer">`phenex.reporting.counts.InExCounts.execute` (12:20)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/counts.py#L22-L35" target="_blank" rel="noopener noreferrer">`phenex.reporting.counts.InExCounts.get_counts_for_phenotypes` (22:35)</a>
+
+
+### Waterfall Module
+This module generates a waterfall diagram or attrition table, showing the sequential impact of inclusion and exclusion criteria on cohort size. It appends phenotype data and calculates deltas in patient numbers.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/waterfall.py#L9-L93" target="_blank" rel="noopener noreferrer">`phenex.reporting.waterfall.Waterfall` (9:93)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/waterfall.py#L22-L62" target="_blank" rel="noopener noreferrer">`phenex.reporting.waterfall.Waterfall.execute` (22:62)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/waterfall.py#L64-L85" target="_blank" rel="noopener noreferrer">`phenex.reporting.waterfall.Waterfall.append_phenotype_to_waterfall` (64:85)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/waterfall.py#L87-L93" target="_blank" rel="noopener noreferrer">`phenex.reporting.waterfall.Waterfall.append_delta` (87:93)</a>
+
+
+### Table1 Module
+This module is dedicated to creating a 'Table 1' report, summarizing baseline characteristics of a cohort. It handles both boolean and value-based characteristics, providing counts, percentages, and summary statistics.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L9-L115" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1` (9:115)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L18-L46" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1.execute` (18:46)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L62-L83" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1._report_boolean_columns` (62:83)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L85-L115" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1._report_value_columns` (85:115)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L48-L53" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1._get_boolean_characteristics` (48:53)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L55-L60" target="_blank" rel="noopener noreferrer">`phenex.reporting.table1.Table1._get_value_characteristics` (55:60)</a>
+
+
+### Cohort Management Module
+This module defines and manages a patient cohort based on entry criteria, inclusions, exclusions, and characteristics. It orchestrates the execution of these criteria and provides an interface to generate reports like Table 1.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/cohort.py#L25-L359" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.cohort.Cohort` (25:359)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/cohort.py#L353-L359" target="_blank" rel="noopener noreferrer">`phenex.phenotypes.cohort.Cohort.table1` (353:359)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,107 @@
+```mermaid
+graph LR
+    Data_Access_Layer["Data Access Layer"]
+    Codelist_Management["Codelist Management"]
+    Data_Transformation_Utilities["Data Transformation & Utilities"]
+    Phenotype_Engine["Phenotype Engine"]
+    Reporting_Analytics["Reporting & Analytics"]
+    Data_Access_Layer -- "provides data to" --> Phenotype_Engine
+    Phenotype_Engine -- "persists results to" --> Data_Access_Layer
+    Data_Transformation_Utilities -- "applies transformations to" --> Phenotype_Engine
+    Codelist_Management -- "supplies criteria to" --> Phenotype_Engine
+    Phenotype_Engine -- "generates reports for" --> Reporting_Analytics
+    Data_Transformation_Utilities -- "serializes/deserializes" --> Codelist_Management
+    Data_Transformation_Utilities -- "serializes/deserializes" --> Phenotype_Engine
+    click Data_Access_Layer href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PhenEx/Data Access Layer.md" "Details"
+    click Codelist_Management href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PhenEx/Codelist Management.md" "Details"
+    click Data_Transformation_Utilities href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PhenEx/Data Transformation & Utilities.md" "Details"
+    click Phenotype_Engine href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PhenEx/Phenotype Engine.md" "Details"
+    click Reporting_Analytics href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PhenEx/Reporting & Analytics.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The PhenEx system is designed for defining, computing, and reporting on patient phenotypes and cohorts from various database sources. It leverages a Data Access Layer to connect to databases and abstract data tables. The core Phenotype Engine utilizes Codelist Management for criteria and Data Transformation & Utilities for filtering and aggregation to define and execute complex phenotypes and manage cohorts. Finally, the Reporting & Analytics component generates insights from the computed cohorts.
+
+### Data Access Layer
+Manages connections to various databases and provides an abstract representation of data tables for querying and manipulation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/ibis_connect.py#L25-L319" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.ibis_connect.SnowflakeConnector` (25:319)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/ibis_connect.py#L322-L354" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.ibis_connect.DuckDBConnector` (322:354)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L8-L152" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.PhenexTable` (8:152)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L183-L195" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.CodeTable` (183:195)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L244-L263" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.MeasurementTable` (244:263)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L155-L170" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.PhenexPersonTable` (155:170)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L230-L241" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.PhenexObservationPeriodTable` (230:241)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L198-L214" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.PhenexVisitOccurrenceTable` (198:214)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L266-L274" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.PhenotypeTable` (266:274)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/tables.py#L173-L180" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.tables.EventTable` (173:180)</a>
+
+
+### Codelist Management
+Provides tools for defining, loading, and manipulating medical codelists from various external sources.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L8-L458" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.codelists.codelists.Codelist` (8:458)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L461-L524" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.codelists.codelists.LocalCSVCodelistFactory` (461:524)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/codelists/codelists.py#L527-L564" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.codelists.codelists.MedConBCodelistFactory` (527:564)</a>
+
+
+### Data Transformation & Utilities
+Offers a framework for filtering and aggregating data, along with utilities for serializing and deserializing PhenEx objects.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L7-L60" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.VerticalDateAggregator` (7:60)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L63-L65" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Nearest` (63:65)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L68-L70" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.First` (68:70)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L73-L75" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Last` (73:75)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L78-L137" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.ValueAggregator` (78:137)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L140-L142" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Mean` (140:142)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L145-L147" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Max` (145:147)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L150-L152" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.Min` (150:152)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L155-L160" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyValueAggregator` (155:160)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L163-L165" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMean` (163:165)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L168-L170" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMedian` (168:170)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L173-L175" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMax` (173:175)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/aggregators/aggregator.py#L178-L180" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.aggregators.aggregator.DailyMin` (178:180)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L7-L62" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.Filter` (7:62)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L65-L80" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.AndFilter` (65:80)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L83-L100" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.OrFilter` (83:100)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/filters/filter.py#L103-L117" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.filters.filter.NotFilter` (103:117)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/to_dict.py#L5-L39" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.util.serialization.to_dict.to_dict` (5:39)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/util/serialization/to_dict.py#L42-L51" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.util.serialization.to_dict.get_phenex_init_params` (42:51)</a>
+
+
+### Phenotype Engine
+Defines the core logic for creating and executing phenotypes and managing patient cohorts based on defined criteria.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/phenotype.py#L15-L184" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.phenotype.Phenotype` (15:184)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/phenotype.py#L194-L346" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.phenotype.ComputationGraph` (194:346)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/cohort.py#L25-L359" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.cohort.Cohort` (25:359)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/phenotypes/cohort.py#L14-L22" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.phenotypes.cohort.subset_and_add_index_date` (14:22)</a>
+
+
+### Reporting & Analytics
+Provides tools for generating reports, summaries, and visualizations from processed data and defined cohorts.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/reporter.py#L1-L13" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.reporting.reporter.Reporter` (1:13)</a>
+- <a href="https://github.com/Bayer-Group/PhenEx/blob/master/phenex/reporting/table1.py#L9-L115" target="_blank" rel="noopener noreferrer">`PhenEx.phenex.reporting.table1.Table1` (9:115)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the PhenEx's codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PhenEx/on_boarding.md

The idea of these diagrams are to help people get up-to-speed with the codebase. I know that a lot of scientists interact with these codebases and I suppose they can make use of such diagrams and grasp the idea much faster than reading the code itself. I would love to hear what do you think about Diagram first documentation for on-boarding and if it fits in your existing on-boarding processes.

We are alos developing a github action which can generate the documentation for every commit in main. It will be available soon so let me know if that sounds interesting!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.