### PR TITLE
Phenotypenameupper

### DIFF
--- a/phenex/ibis_connect.py
+++ b/phenex/ibis_connect.py
@@ -249,7 +249,7 @@ class SnowflakeConnector:
             self.dest_connection.create_database(name=database, catalog=catalog)
 
         return self.dest_connection.create_view(
-            name=name_table,
+            name=name_table.upper(),
             database=database,
             obj=table,
             overwrite=overwrite,
@@ -279,7 +279,7 @@ class SnowflakeConnector:
             self.dest_connection.create_database(name=database, catalog=catalog)
 
         return self.dest_connection.create_table(
-            name=name_table,
+            name=name_table.upper(),
             database=database,
             obj=table,
             overwrite=overwrite,

--- a/phenex/phenotypes/age_phenotype.py
+++ b/phenex/phenotypes/age_phenotype.py
@@ -59,13 +59,12 @@ class AgePhenotype(Phenotype):
 
     def __init__(
         self,
-        name: str = "age",
+        name: Optional[str] = "AGE",
         value_filter: Optional[ValueFilter] = None,
         anchor_phenotype: Optional[Phenotype] = None,
         domain: str = "PERSON",
         **kwargs,
     ):
-        self.name = name
         self.min_age = self.max_age = None
         if value_filter:
             self.min_age = value_filter.min_value
@@ -84,7 +83,7 @@ class AgePhenotype(Phenotype):
         else:
             self.children = []
 
-        super(AgePhenotype, self).__init__(**kwargs)
+        super(AgePhenotype, self).__init__(name=name, **kwargs)
 
     def _execute(self, tables: Dict[str, Table]) -> PhenotypeTable:
         person_table = tables[self.domain]

--- a/phenex/phenotypes/categorical_phenotype.py
+++ b/phenex/phenotypes/categorical_phenotype.py
@@ -24,13 +24,11 @@ class CategoricalPhenotype(Phenotype):
 
     def __init__(
         self,
-        name: str = None,
         domain: str = None,
         allowed_values: List = None,
         column_name: str = None,
         **kwargs,
     ):
-        self.name = name
         self.categorical_filter = CategoricalFilter(
             allowed_values=allowed_values, domain=domain, column_name=column_name
         )

--- a/phenex/phenotypes/codelist_phenotype.py
+++ b/phenex/phenotypes/codelist_phenotype.py
@@ -102,12 +102,13 @@ class CodelistPhenotype(Phenotype):
         categorical_filter: Optional["CategoricalFilter"] = None,
         **kwargs,
     ):
-        super(CodelistPhenotype, self).__init__(**kwargs)
+        if name is None:
+            name = codelist.name
+        super(CodelistPhenotype, self).__init__(name=name, **kwargs)
 
         self.codelist_filter = CodelistFilter(codelist)
         self.codelist = codelist
         self.categorical_filter = categorical_filter
-        self.name = name or self.codelist.name
         self.date_range = date_range
         self.return_date = return_date
         assert self.return_date in [

--- a/phenex/phenotypes/cohort.py
+++ b/phenex/phenotypes/cohort.py
@@ -122,7 +122,7 @@ class Cohort(Phenotype):
                     futures[key] = executor.submit(
                         con.create_table,
                         table.table,
-                        f"{self.name}__subset_entry_{key}",
+                        f"{self.name}__subset_entry_{key}".upper(),
                         overwrite,
                     )
                 for key, future in futures.items():
@@ -140,7 +140,7 @@ class Cohort(Phenotype):
                 logger.debug("Writing inclusions table ...")
                 self.inclusions_table = con.create_table(
                     self.inclusions_table,
-                    f"{self.name}__inclusions",
+                    f"{self.name}__inclusions".upper(),
                     overwrite=overwrite,
                 )
             include = self.inclusions_table.filter(
@@ -157,7 +157,7 @@ class Cohort(Phenotype):
                 logger.debug("Writing exclusions table ...")
                 self.exclusions_table = con.create_table(
                     self.exclusions_table,
-                    f"{self.name}__exclusions",
+                    f"{self.name}__exclusions".upper(),
                     overwrite=overwrite,
                 )
             exclude = self.exclusions_table.filter(
@@ -170,7 +170,7 @@ class Cohort(Phenotype):
         if con:
             logger.debug("Writing index table ...")
             self.index_table = con.create_table(
-                index_table, f"{self.name}__index", overwrite=overwrite
+                index_table, f"{self.name}__index".upper(), overwrite=overwrite
             )
 
         self.subset_tables_index = subset_and_add_index_date(tables, self.index_table)
@@ -182,7 +182,7 @@ class Cohort(Phenotype):
                     futures[key] = executor.submit(
                         con.create_table,
                         table.table,
-                        f"{self.name}__subset_index_{key}",
+                        f"{self.name}__subset_index_{key}".upper(),
                         overwrite,
                     )
                 for key, future in futures.items():
@@ -197,7 +197,7 @@ class Cohort(Phenotype):
                 logger.debug("Writing characteristics table ...")
                 self.characteristics_table = con.create_table(
                     self.characteristics_table,
-                    f"{self.name}__characteristics",
+                    f"{self.name}__characteristics".upper(),
                     overwrite=overwrite,
                 )
             logger.debug("Characteristics computed.")

--- a/phenex/phenotypes/cohort.py
+++ b/phenex/phenotypes/cohort.py
@@ -49,7 +49,6 @@ class Cohort(Phenotype):
 
     def __init__(
         self,
-        name: str,
         entry_criterion: Phenotype,
         inclusions: Optional[List[Phenotype]] = None,
         exclusions: Optional[List[Phenotype]] = None,
@@ -58,7 +57,6 @@ class Cohort(Phenotype):
         **kwargs,
     ):
         super(Cohort, self).__init__(**kwargs)
-        self.name = name
         self.entry_criterion = entry_criterion
         self.inclusions = inclusions if inclusions is not None else []
         self.exclusions = exclusions if exclusions is not None else []

--- a/phenex/phenotypes/computation_graph_phenotypes.py
+++ b/phenex/phenotypes/computation_graph_phenotypes.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 from datetime import date
 from ibis.expr.types.relations import Table
 import ibis
@@ -38,32 +38,23 @@ class ComputationGraphPhenotype(Phenotype):
         self,
         expression: ComputationGraph,
         return_date: Union[str, Phenotype],
-        name: str = None,
+        name: Optional[str] = None,
         aggregation_index=["PERSON_ID"],
         operate_on: str = "boolean",
         populate: str = "value",
         reduce: bool = False,
         **kwargs,
     ):
-        super(ComputationGraphPhenotype, self).__init__(**kwargs)
+        if name is None:
+            name = str(expression)
+        super(ComputationGraphPhenotype, self).__init__(name=name, **kwargs)
         self.expression = expression
         self.return_date = return_date
         self.aggregation_index = aggregation_index
-        self._name = name
         self.operate_on = operate_on
         self.populate = populate
         self.reduce = reduce
         self.children = self.expression.get_leaf_phenotypes()
-
-    @property
-    def name(self):
-        if self._name is None:
-            self._name = str(self.expression)
-        return self._name
-
-    @name.setter
-    def name(self, name):
-        self._name = name
 
     def _execute(self, tables: Dict[str, Table]) -> PhenotypeTable:
         """

--- a/phenex/phenotypes/continuous_coverage_phenotype.py
+++ b/phenex/phenotypes/continuous_coverage_phenotype.py
@@ -58,15 +58,14 @@ class ContinuousCoveragePhenotype(Phenotype):
 
     def __init__(
         self,
-        name: Optional[str] = "continuous_coverage",
+        name: Optional[str] = "CONTINUOUS_COVERAGE",
         domain: Optional[str] = "OBSERVATION_PERIOD",
         value_filter: Optional[ValueFilter] = None,
         when: Optional[str] = "before",
         anchor_phenotype: Optional[Phenotype] = None,
         **kwargs
     ):
-        super().__init__(**kwargs)
-        self.name = name
+        super().__init__(name=name, **kwargs)
         self.domain = domain
         self.when = when
         self.value_filter = value_filter

--- a/phenex/phenotypes/death_phenotype.py
+++ b/phenex/phenotypes/death_phenotype.py
@@ -22,14 +22,13 @@ class DeathPhenotype(Phenotype):
 
     def __init__(
         self,
-        name: str = "death",
+        name: Optional[str] = "DEATH",
         domain: str = "PERSON",
         relative_time_range: Union[
             RelativeTimeRangeFilter, List[RelativeTimeRangeFilter]
         ] = None,
         **kwargs
     ):
-        self.name = name
         self.domain = domain
         self.children = []
         self.relative_time_range = relative_time_range
@@ -39,7 +38,7 @@ class DeathPhenotype(Phenotype):
             for rtr in self.relative_time_range:
                 if rtr.anchor_phenotype is not None:
                     self.children.append(rtr.anchor_phenotype)
-        super(DeathPhenotype, self).__init__(**kwargs)
+        super(DeathPhenotype, self).__init__(name=name, **kwargs)
 
     def _execute(self, tables: Dict[str, Table]) -> PhenotypeTable:
         person_table = tables[self.domain]

--- a/phenex/phenotypes/measurement_change_phenotype.py
+++ b/phenex/phenotypes/measurement_change_phenotype.py
@@ -45,7 +45,6 @@ class MeasurementChangePhenotype(Phenotype):
 
     def __init__(
         self,
-        name: str,
         phenotype: MeasurementPhenotype,
         min_change: Value = None,
         max_change: Value = None,
@@ -58,7 +57,6 @@ class MeasurementChangePhenotype(Phenotype):
         **kwargs,
     ):
         super(MeasurementChangePhenotype, self).__init__(**kwargs)
-        self.name = name
         self.phenotype = phenotype
         self.min_change = min_change
         self.max_change = max_change

--- a/phenex/phenotypes/multiple_occurrences_phenotype.py
+++ b/phenex/phenotypes/multiple_occurrences_phenotype.py
@@ -47,7 +47,6 @@ class MultipleOccurrencesPhenotype(Phenotype):
 
     def __init__(
         self,
-        name: str,
         phenotype: Phenotype,
         n_occurrences: int = 2,
         date_range: DateFilter = None,
@@ -55,7 +54,6 @@ class MultipleOccurrencesPhenotype(Phenotype):
         return_date="first",
         **kwargs
     ):
-        self.name = name
         self.date_range = date_range
         self.relative_time_range = relative_time_range
         self.return_date = return_date

--- a/phenex/phenotypes/phenotype.py
+++ b/phenex/phenotypes/phenotype.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 from ibis.expr.types.relations import Table
 from deepdiff import DeepDiff
 from phenex.tables import (
@@ -32,14 +32,25 @@ class Phenotype:
         description: A plain text description of the phenotype.
     """
 
-    def __init__(self, description: str = None):
+    def __init__(self, name: Optional[str] = None, description: Optional[str] = None):
         self.table = (
             None  # self.table is populated ONLY AFTER self.execute() is called!
         )
+        self._name = name
         self._namespaced_table = None
         self.children = []  # List[Phenotype]
         self.description = description
         self._check_for_children()
+
+    @property
+    def name(self):
+        if self._name is not None:
+            return self._name.upper()
+        return "PHENOTYPE"  # TODO replace with phenotype id when phenotype id is implemented
+
+    @name.setter
+    def name(self, name):
+        self._name = name
 
     def execute(self, tables: Dict[str, Table]) -> PhenotypeTable:
         """

--- a/phenex/phenotypes/sex_phenotype.py
+++ b/phenex/phenotypes/sex_phenotype.py
@@ -32,7 +32,7 @@ class SexPhenotype(CategoricalPhenotype):
 
     def __init__(
         self,
-        name: str = "sex",
+        name: str = "SEX",
         allowed_values: Optional[List[Union[str, int, float]]] = None,
         domain: str = "PERSON",
         column_name="SEX",

--- a/phenex/phenotypes/within_same_encounter_phenotype.py
+++ b/phenex/phenotypes/within_same_encounter_phenotype.py
@@ -53,14 +53,12 @@ class WithinSameEncounterPhenotype(Phenotype):
 
     def __init__(
         self,
-        name: str,
         anchor_phenotype: Union["CodelistPhenotype", "MeasurementPhenotype"],
         phenotype: Union["CodelistPhenotype", "MeasurementPhenotype"],
         column_name: str,
         **kwargs,
     ):
         super(WithinSameEncounterPhenotype, self).__init__(**kwargs)
-        self.name = name
         if (
             anchor_phenotype.__class__.__name__
             not in ["CodelistPhenotype", "MeasurementPhenotype"]

--- a/phenex/test/cohort/test_cprd_endocrine_therapy_cohort_with_dummy_data.py
+++ b/phenex/test/cohort/test_cprd_endocrine_therapy_cohort_with_dummy_data.py
@@ -181,11 +181,14 @@ class SimpleCohortTestGenerator(CohortTestGenerator):
     def define_expected_output(self):
         df_counts_inclusion = pd.DataFrame()
         df_counts_inclusion["phenotype"] = [
-            "breast_cancer",
-            "continuous_coverage",
-            "data_quality",
-            "age",
-            "sex",
+            x.upper()
+            for x in [
+                "breast_cancer",
+                "continuous_coverage",
+                "data_quality",
+                "age",
+                "sex",
+            ]
         ]
         df_counts_inclusion["n"] = [16, 32, 32, 32, 32]
 

--- a/phenex/test/phenotypes/test_age_phenotype.py
+++ b/phenex/test/phenotypes/test_age_phenotype.py
@@ -222,8 +222,10 @@ class AgePhenotypeImputeMonthDayTestGenerator(PhenotypeTestGenerator):
         for test_info in test_infos:
             test_info["phenotype"] = AgePhenotype(
                 name=test_info["name"],
-                min_age=test_info.get("min_age"),
-                max_age=test_info.get("max_age"),
+                value_filter=ValueFilter(
+                    min_value=test_info.get("min_age"),
+                    max_value=test_info.get("max_age"),
+                ),
                 # impute_day=1,
                 # impute_month=6,
             )
@@ -234,5 +236,12 @@ class AgePhenotypeImputeMonthDayTestGenerator(PhenotypeTestGenerator):
 def test_age_phenotype():
     spg = AgePhenotypeTestGenerator()
     spg.run_tests()
-    # spg = AgePhenotypeImputeMonthDayTestGenerator()
-    # spg.generate()
+
+
+# def test_impute_month_age_phenotype():
+#     spg = AgePhenotypeImputeMonthDayTestGenerator()
+#     spg.run_tests()
+
+if __name__ == "__main__":
+    test_age_phenotype()
+    test_impute_month_age_phenotype()


### PR DESCRIPTION
ibis allows lowercase in table names and column names. this is messy because snowpark and R don't allow this and neither does SQL. We should require all table and column names to be capitalized to improve compatibility with downstream usage. This implementation ensures uppercase table names and column names by :
1.  all phenotype names uppercase, meaning that all column names using phenotype names will also be capitalized. 
2. all tables written by the cohort will be upper case, as the table create enforces uppercase when writing