### PR TITLE
added fix for logic phenotype if expression is negation of a single item

### DIFF
--- a/phenex/phenotypes/computation_graph_phenotypes.py
+++ b/phenex/phenotypes/computation_graph_phenotypes.py
@@ -157,6 +157,8 @@ class ComputationGraphPhenotype(Phenotype):
         coalesce_expressions = []
 
         names = [col for col in table.columns if "EVENT_DATE" in col]
+        if len(names) == 1:
+            return [table[names[0]]]
 
         for i in range(len(names)):
             rotated_names = names[i:] + names[:i]


### PR DESCRIPTION
LogicPhenotype was failing when expression was negation of a single phenotype when using a SnowflakeBackend. Negation of a single phenotype was tested using DuckDB in the unit tests, but for some reason when run in Snowflake produced an error. This is related to the coalesce to fill in non-null dates for horizontal date selection; Snowflake backend did not like coalesce with a single column name. Have implemented the fix; if only a single column is present, return selection of that column.