### PR TITLE
Fix to Waterfall Reporter

### DIFF
--- a/phenex/reporting/waterfall.py
+++ b/phenex/reporting/waterfall.py
@@ -96,7 +96,7 @@ class Waterfall(Reporter):
                 "Name": (
                     phenotype.display_name if self.pretty_display else phenotype.name
                 ),
-                "N": phenotype.table.count().execute(),
+                "N": phenotype.table.select("PERSON_ID").distinct().count().execute(),
                 "Remaining": table.count().execute(),
             }
         )


### PR DESCRIPTION
**Fixed Waterfall reporter count of N** : Previously, waterfall reporter was counting number of events and not number of distinct patient ids. `N` column fixed to display number of unique patient ids with a given inclusion/exclusion criteria on that row.