### PR TITLE
Fix Table 1

### DIFF
--- a/phenex/util/logging.py
+++ b/phenex/util/logging.py
@@ -21,5 +21,5 @@ def create_logger(name):
 
         # Add console handler to logger
         logger.addHandler(console_handler)
-    
+
     return logger


### PR DESCRIPTION
**Fixed strange behavior in Table1 Reporter** : table 1 had strange behavior, placing counts with wrong phenotypes; the counts were correct for *a* phenotype, but assigned to the incorrect label. The implementation of Table1 Reporter was changed from using the baseline characteristics table to using the phenotype tables themselves. This solves the issue. Additional changes to logging to prevent multiple log statements.