### PR TITLE
Fix/score phenotype to categorical

### DIFF
--- a/phenex/reporting/table1.py
+++ b/phenex/reporting/table1.py
@@ -80,6 +80,7 @@ class Table1(Reporter):
                 "CategoricalPhenotype",
                 "SexPhenotype",
                 "ArithmeticPhenotype",
+                "EventCountPhenotype",
             ]
         ]
 
@@ -92,8 +93,8 @@ class Table1(Reporter):
                 "MeasurementPhenotype",
                 "AgePhenotype",
                 "TimeRangePhenotype",
-                "ScorePhenotype",
                 "ArithmeticPhenotype",
+                "EventCountPhenotype",  # event count is a value; show summary statistics for number of days
             ]
         ]
 
@@ -101,7 +102,12 @@ class Table1(Reporter):
         return [
             x
             for x in self.cohort.characteristics
-            if type(x).__name__ in ["CategoricalPhenotype", "SexPhenotype"]
+            if type(x).__name__
+            in [
+                "CategoricalPhenotype",
+                "SexPhenotype",
+                "ScorePhenotype",  # score is categorical; show number of patients in each score category
+            ]
         ]
 
     def _get_boolean_count_for_phenotype(self, phenotype):

--- a/phenex/reporting/table1.py
+++ b/phenex/reporting/table1.py
@@ -80,7 +80,6 @@ class Table1(Reporter):
                 "CategoricalPhenotype",
                 "SexPhenotype",
                 "ArithmeticPhenotype",
-                "EventCountPhenotype",
             ]
         ]
 

--- a/phenex/reporting/table1.py
+++ b/phenex/reporting/table1.py
@@ -61,7 +61,7 @@ class Table1(Reporter):
         if self.pretty_display:
             self.create_pretty_display()
 
-        self.df = self.df.sort_values(by="inex_order")
+        self.df = self.df.sort_values(by=["inex_order", "Name"])
         self.df = self.df.reset_index()[
             [x for x in self.df.columns if x not in ["index", "inex_order"]]
         ]
@@ -80,6 +80,7 @@ class Table1(Reporter):
                 "CategoricalPhenotype",
                 "SexPhenotype",
                 "ArithmeticPhenotype",
+                "BinPhenotype",
             ]
         ]
 
@@ -106,6 +107,7 @@ class Table1(Reporter):
                 "CategoricalPhenotype",
                 "SexPhenotype",
                 "ScorePhenotype",  # score is categorical; show number of patients in each score category
+                "BinPhenotype",
             ]
         ]
 


### PR DESCRIPTION
**Fixed reporting of BinPhenotype, ScorePhenotype and EventCountPhenotype in Table1 Reporter** : 
- BinPhenotype is reported as a categorical value, so each bin is displayed in table1 automatically with count of patients in that bin
- ScorePhenotype is now reported as a categorical value, so each score and count of patients with that score are automatically added to Table1
- EventCountPhenotype is now reported as a numerical value, so the summary statistics are displayed automatically in Table1