### PR TITLE
Fix/visit detail mappers

### DIFF
--- a/phenex/mappers.py
+++ b/phenex/mappers.py
@@ -82,6 +82,7 @@ class OMOPVisitOccurrenceTable(PhenexObservationPeriodTable):
     JOIN_KEYS = {
         "OMOPPersonTable": ["PERSON_ID"],
         "OMOPConditionOccurenceTable": ["PERSON_ID", "VISIT_OCCURRENCE_ID"],
+        "OMOPDrugExposureTable": ["PERSON_ID", "VISIT_OCCURRENCE_ID"],
         "OMOPVisitDetailTable": ["PERSON_ID", "VISIT_OCCURRENCE_ID"],
     }
     DEFAULT_MAPPING = {
@@ -91,11 +92,16 @@ class OMOPVisitOccurrenceTable(PhenexObservationPeriodTable):
     }
 
 
-class OMOPVisitDetailTable(PhenexTable):
+class OMOPVisitDetailTable(PhenexObservationPeriodTable):
     NAME_TABLE = "VISIT_DETAIL"
     RELATIONSHIPS = {
         "OMOPPersonTable": ["PERSON_ID"],
         "OMOPVisitOccurrenceTable": ["PERSON_ID", "VISIT_OCCURRENCE_ID"],
+    }
+    DEFAULT_MAPPING = {
+        "PERSON_ID": "PERSON_ID",
+        "START_DATE": "VISIT_DETAIL_START_DATE",
+        "END_DATE": "VISIT_DETAIL_END_DATE",
     }
 
 
@@ -183,6 +189,10 @@ class OMOPDrugExposureTable(CodeTable):
         "PERSON_ID": "PERSON_ID",
         "EVENT_DATE": "DRUG_EXPOSURE_START_DATE",
         "CODE": "DRUG_CONCEPT_ID",
+    }
+
+    PATHS = {
+        "OMOPVisitDetailTable": ["OMOPVisitOccurrenceTable"],
     }
 
 

--- a/phenex/node.py
+++ b/phenex/node.py
@@ -221,7 +221,6 @@ class Node:
         return self._get_current_hash()
 
     def _update_current_hash(self):
-
         con = DuckDBConnector(DUCKDB_DEST_DATABASE=NODE_STATES_DB_NAME)
 
         df = pd.DataFrame.from_dict(

--- a/phenex/phenotypes/cohort.py
+++ b/phenex/phenotypes/cohort.py
@@ -149,17 +149,21 @@ class Cohort:
             + self.outcomes
         )
         all_nodes = top_level_nodes + sum([t.dependencies for t in top_level_nodes], [])
+
         # FIXME Person domain should not be HARD CODED; however, it IS hardcoded in SCORE phenotype. Remove hardcoding!
-        domains = list(
-            set(
-                ["PERSON"]
-                + [
-                    getattr(pt, "domain", None)
-                    for pt in all_nodes
-                    if getattr(pt, "domain", None) is not None
-                ]
-            )
-        )
+        domains = ["PERSON"] + [
+            getattr(pt, "domain", None)
+            for pt in all_nodes
+            if getattr(pt, "domain", None) is not None
+        ]
+
+        domains += [
+            getattr(getattr(pt, "categorical_filter", None), "domain", None)
+            for pt in all_nodes
+            if getattr(getattr(pt, "categorical_filter", None), "domain", None)
+            is not None
+        ]
+        domains = list(set(domains))
         return domains
 
     def _get_subset_tables_nodes(self, stage: str, index_phenotype: Phenotype):
@@ -413,7 +417,6 @@ class InclusionsTableNode(Node):
         self.index_phenotype = index_phenotype
 
     def _execute(self, tables: Dict[str, Table]):
-
         inclusions_table = self.index_phenotype.table.select(["PERSON_ID"])
 
         for pt in self.phenotypes:
@@ -458,7 +461,6 @@ class ExclusionsTableNode(Node):
         self.index_phenotype = index_phenotype
 
     def _execute(self, tables: Dict[str, Table]):
-
         exclusions_table = self.index_phenotype.table.select(["PERSON_ID"])
 
         for pt in self.phenotypes:
@@ -514,7 +516,6 @@ class IndexTableNode(Node):
         self.exclusion_table_node = exclusion_table_node
 
     def _execute(self, tables: Dict[str, Table]):
-
         index_table = self.entry_phenotype.table.mutate(INDEX_DATE="EVENT_DATE")
 
         if self.inclusion_table_node:

--- a/phenex/test/cohort/test_cohort_various_phenotypes_as_inex.py
+++ b/phenex/test/cohort/test_cohort_various_phenotypes_as_inex.py
@@ -735,7 +735,6 @@ class CohortWithUDPTestGenerator(CohortTestGenerator):
     """
 
     def define_cohort(self):
-
         def user_defined_function(mapped_tables):
             df = pd.DataFrame()
             df["PERSON_ID"] = ["P0", "P1", "P2", "P3", "P4"]

--- a/phenex/test/phenotypes/test_event_count_phenotype.py
+++ b/phenex/test/phenotypes/test_event_count_phenotype.py
@@ -22,7 +22,6 @@ class EventCountTestGenerator(PhenotypeTestGenerator):
     test_date = True
 
     def define_input_tables(self):
-
         df = pd.DataFrame()
         df["PERSON_ID"] = ["P1", "P1", "P1", "P1", "P2", "P2"]
         df["CODE"] = "c1"
@@ -47,7 +46,6 @@ class EventCountTestGenerator(PhenotypeTestGenerator):
         ]
 
     def define_phenotype_tests(self):
-
         pt1_prior = CodelistPhenotype(
             codelist=Codelist("c1"),
             domain="condition_occurrence",

--- a/phenex/test/phenotypes/test_user_defined_phenotype.py
+++ b/phenex/test/phenotypes/test_user_defined_phenotype.py
@@ -38,7 +38,6 @@ class UserDefinedPhenotypeTestGenerator(PhenotypeTestGenerator):
         return [input_info_person]
 
     def define_phenotype_tests(self):
-
         def function1(mapped_tables):
             df = pd.DataFrame()
             df["PERSON_ID"] = ["P1", "P2", "P3", "P4", "P5"]


### PR DESCRIPTION
**Fixed visit detail mappers: ** visit detail table mappers did not have a path to drug_exposure. No autojoin filtering works between drug_exposure and visit detail (over visit occurrence table). Have not done for condition occurrence 