### PR TITLE
Feat/binnedcategories

### DIFF
--- a/phenex/phenotypes/bin_phenotype.py
+++ b/phenex/phenotypes/bin_phenotype.py
@@ -79,6 +79,7 @@ class BinPhenotype(Phenotype):
         # Result will have VALUE column with labels like "Acute MI", "MI Complications", etc.
         ```
     """
+
     def __init__(
         self,
         phenotype: Phenotype,
@@ -137,13 +138,7 @@ class BinPhenotype(Phenotype):
         if (
             self.value_mapping is not None
             and self.phenotype.__class__.__name__
-            not in [
-                "CodelistPhenotype",
-                "AgePhenotype",
-                "MeasurementPhenotype",
-                "ArithmeticPhenotype",
-                "ScorePhenotype",
-            ]
+            not in ["CodelistPhenotype", "CategoricalPhenotype"]
         ):
             raise ValueError(
                 f"Invalid phenotype type for discrete mapping: {self.phenotype.__class__.__name__}"

--- a/phenex/phenotypes/bin_phenotype.py
+++ b/phenex/phenotypes/bin_phenotype.py
@@ -1,5 +1,6 @@
 import ibis
 from ibis import _
+from typing import Dict, List, Union, Optional
 
 from phenex.phenotypes.phenotype import Phenotype
 from phenex.filters.relative_time_range_filter import RelativeTimeRangeFilter
@@ -14,63 +15,159 @@ logger = create_logger(__name__)
 
 class BinPhenotype(Phenotype):
     """
-    BinPhenotype converts numeric values into categorical bin labels. To use, pass it a numeric valued phenotype such as AgePhenotype, MeasurementPhenotype, ArithmeticPhenotype, or ScorePhenotype.
+    BinPhenotype converts values into categorical bin labels. Supports both continuous numeric binning and discrete value mapping.
 
-    Takes a phenotype that returns numeric values (like age, measurements, etc.)
+    For continuous values: Takes a phenotype that returns numeric values (like age, measurements, etc.)
     and converts the VALUE column into bin labels like "[10-20)", "[20-30)", etc.
 
+    For discrete values: Takes a phenotype that returns discrete values (like codes from CodelistPhenotype)
+    and maps them to categorical labels using a bin mapping dictionary.
+
     DATE: The event date selected from the input phenotype
-    VALUE: A categorical variable representing the bin label that the numeric value falls into
+    VALUE: A categorical variable representing the bin label
 
     Parameters:
         name: The name of the phenotype.
-        phenotype: The phenotype that returns numeric values of interest (AgePhenotype, MeasurementPhenotype, etc.)
-        bins: List of bin edges. Default is [0, 10, 20, ..., 100] for age ranges.
+        phenotype: The phenotype that returns values of interest (AgePhenotype, MeasurementPhenotype, CodelistPhenotype, etc.)
+        bins: List of bin edges for continuous binning. Default is [0, 10, 20, ..., 100] for age ranges.
+        value_mapping: Dictionary mapping bin names to lists of values (e.g., {"Heart Disease": ["I21", "I22", "I23"]})
 
-    Example:
+    Examples:
         ```python
-        # Create an age phenotype
+        # Continuous binning example
         age = AgePhenotype()
-
-        # Create bins for age groups: [0-10), [10-20), [20-30), etc.
         binned_age = BinPhenotype(
             name="age_groups",
             phenotype=age,
             bins=[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
         )
 
+        # Discrete mapping example
+        diagnosis_codes = CodelistPhenotype(
+            name="diagnosis",
+            codelist=["I21", "I22", "I23", "I24", "I25"],
+            return_value="all"
+        )
+        diagnosis_categories = BinPhenotype(
+            name="diagnosis_categories",
+            phenotype=diagnosis_codes,
+            value_mapping={
+                "Acute MI": ["I21", "I22"],
+                "MI Complications": ["I23", "I24"],
+                "Chronic Heart Disease": ["I25"]
+            }
+        )
+
         tables = {"PERSON": example_person_table}
         result_table = binned_age.execute(tables)
-
         # Result will have VALUE column with labels like "[20-30)", "[30-40)", etc.
-        display(result_table)
+
+        result_table = diagnosis_categories.execute(tables)
+        # Result will have VALUE column with labels like "Acute MI", "MI Complications", etc.
         ```
     """
 
     def __init__(
         self,
         phenotype: Phenotype,
-        bins=list(range(0, 101, 10)),
+        bins: Optional[List[Union[int, float]]] = None,
+        value_mapping: Optional[Dict[str, List[str]]] = None,
         **kwargs,
     ):
+        """
+        Create bins from a phenotype's VALUE column.
+
+        Supports two modes:
+        1. Continuous binning: Use 'bins' parameter for numeric ranges
+        2. Discrete mapping: Use 'value_mapping' parameter for bin-to-values mapping
+
+        Args:
+            phenotype: The phenotype to bin values from
+            bins: List of bin edges for continuous values (e.g., [0, 10, 20, 30])
+                 Default is [0, 10, 20, ..., 100] for backward compatibility
+            value_mapping: Dictionary mapping bin names to lists of values
+                          (e.g., {"Heart Disease": ["I21", "I22", "I23"], "Diabetes": ["E10", "E11"]})
+        """
         super(BinPhenotype, self).__init__(**kwargs)
+
+        # Set default bins for backward compatibility if neither parameter is provided
+        if bins is None and value_mapping is None:
+            bins = list(range(0, 101, 10))
+
+        # Validate that only one binning method is specified
+        if bins is not None and value_mapping is not None:
+            raise ValueError(
+                "Cannot specify both 'bins' and 'value_mapping' - choose one"
+            )
+
         self.bins = bins
+        self.value_mapping = value_mapping
         self.phenotype = phenotype
-        if self.phenotype.__class__.__name__ not in [
+
+        # Validate continuous binning
+        if self.bins is not None:
+            if len(self.bins) < 2:
+                raise ValueError("bins must contain at least 2 values")
+            if self.bins != sorted(self.bins):
+                raise ValueError("bins must be sorted in ascending order")
+
+        # Validate discrete mapping
+        if self.value_mapping is not None:
+            if not isinstance(self.value_mapping, dict):
+                raise ValueError("value_mapping must be a dictionary")
+            if len(self.value_mapping) == 0:
+                raise ValueError("value_mapping cannot be empty")
+            # Validate that all values are lists of strings
+            for bin_name, values in self.value_mapping.items():
+                if not isinstance(values, list):
+                    raise ValueError(f"Values for bin '{bin_name}' must be a list")
+                if not all(isinstance(v, str) for v in values):
+                    raise ValueError(f"All values for bin '{bin_name}' must be strings")
+
+        # Validate phenotype types for continuous binning
+        if self.bins is not None and self.phenotype.__class__.__name__ not in [
             "AgePhenotype",
             "MeasurementPhenotype",
             "ArithmeticPhenotype",
             "ScorePhenotype",
         ]:
             raise ValueError(
-                f"Invalid phenotype type: {self.phenotype.__class__.__name__}"
+                f"Invalid phenotype type for continuous binning: {self.phenotype.__class__.__name__}"
             )
+
+        # For discrete mapping, allow CodelistPhenotype and other string-based phenotypes
+        if (
+            self.value_mapping is not None
+            and self.phenotype.__class__.__name__
+            not in [
+                "CodelistPhenotype",
+                "AgePhenotype",
+                "MeasurementPhenotype",
+                "ArithmeticPhenotype",
+                "ScorePhenotype",
+            ]
+        ):
+            raise ValueError(
+                f"Invalid phenotype type for discrete mapping: {self.phenotype.__class__.__name__}"
+            )
+
         self.add_children(phenotype)
 
     def _execute(self, tables) -> PhenotypeTable:
         # Execute the child phenotype to get the initial table to filter
         table = self.phenotype.table
 
+        if self.bins is not None:
+            # Continuous binning logic
+            table = self._execute_continuous_binning(table)
+        else:
+            # Discrete mapping logic
+            table = self._execute_discrete_mapping(table)
+
+        return table
+
+    def _execute_continuous_binning(self, table) -> PhenotypeTable:
+        """Handle continuous value binning with numeric ranges."""
         # Create bin labels
         bin_labels = []
 
@@ -107,6 +204,27 @@ class BinPhenotype(Phenotype):
         case_expr = case_expr.else_(None)
 
         # Replace the VALUE column with bin labels
+        table = table.mutate(VALUE=case_expr.end())
+
+        return table
+
+    def _execute_discrete_mapping(self, table) -> PhenotypeTable:
+        """Handle discrete value mapping with bin-to-values dictionary."""
+        value_col = table.VALUE
+
+        # Start with the case expression
+        case_expr = ibis.case()
+
+        # Add conditions for each bin and its associated values
+        for bin_name, values in self.value_mapping.items():
+            # Create condition that checks if value is in the list of values for this bin
+            condition = value_col.isin(values)
+            case_expr = case_expr.when(condition, bin_name)
+
+        # Handle unmapped values as null
+        case_expr = case_expr.else_(None)
+
+        # Replace the VALUE column with mapped labels
         table = table.mutate(VALUE=case_expr.end())
 
         return table

--- a/phenex/phenotypes/bin_phenotype.py
+++ b/phenex/phenotypes/bin_phenotype.py
@@ -17,11 +17,9 @@ class BinPhenotype(Phenotype):
     """
     BinPhenotype converts values into categorical bin labels. Supports both continuous numeric binning and discrete value mapping.
 
-    For continuous values: Takes a phenotype that returns numeric values (like age, measurements, etc.)
-    and converts the VALUE column into bin labels like "[10-20)", "[20-30)", etc.
+    For continuous values: Takes a phenotype that returns numeric values (like age, measurements, etc.) and converts the VALUE column into bin labels like "[10-20)", "[20-30)", etc.
 
-    For discrete values: Takes a phenotype that returns discrete values (like codes from CodelistPhenotype)
-    and maps them to categorical labels using a bin mapping dictionary.
+    For discrete values: Takes a phenotype that returns discrete values (like codes from CodelistPhenotype) and maps them to categorical labels using a bin mapping dictionary.
 
     DATE: The event date selected from the input phenotype
     VALUE: A categorical variable representing the bin label

--- a/phenex/phenotypes/bin_phenotype.py
+++ b/phenex/phenotypes/bin_phenotype.py
@@ -7,6 +7,7 @@ from phenex.filters.relative_time_range_filter import RelativeTimeRangeFilter
 from phenex.filters import DateFilter, ValueFilter
 from phenex.tables import is_phenex_code_table, PHENOTYPE_TABLE_COLUMNS, PhenotypeTable
 from phenex.aggregators import First, Last
+from phenex.codelists import Codelist
 
 from phenex.util import create_logger
 
@@ -31,8 +32,12 @@ class BinPhenotype(Phenotype):
         value_mapping: Dictionary mapping bin names to lists of values (e.g., {"Heart Disease": ["I21", "I22", "I23"]})
 
     Examples:
+
+    Example: Binning on continuous value
         ```python
         # Continuous binning example
+        from phenex.phenotypes import AgePhenotype
+
         age = AgePhenotype()
         binned_age = BinPhenotype(
             name="age_groups",
@@ -40,10 +45,20 @@ class BinPhenotype(Phenotype):
             bins=[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
         )
 
+    Example: Binning on discrete value
+        ```python
         # Discrete mapping example
+        from phenex.phenotypes import CodelistPhenotype
+        from phenex.codelists import Codelist
+
+        diagnosis_codelist = Codelist(
+            name="diagnosis_codes",
+            codelist=["I21", "I22", "I23", "I24", "I25"]
+        )
         diagnosis_codes = CodelistPhenotype(
             name="diagnosis",
-            codelist=["I21", "I22", "I23", "I24", "I25"],
+            domain="CONDITION_OCCURRENCE",
+            codelist=diagnosis_codelist,
             return_value="all"
         )
         diagnosis_categories = BinPhenotype(
@@ -64,7 +79,6 @@ class BinPhenotype(Phenotype):
         # Result will have VALUE column with labels like "Acute MI", "MI Complications", etc.
         ```
     """
-
     def __init__(
         self,
         phenotype: Phenotype,
@@ -72,20 +86,6 @@ class BinPhenotype(Phenotype):
         value_mapping: Optional[Dict[str, List[str]]] = None,
         **kwargs,
     ):
-        """
-        Create bins from a phenotype's VALUE column.
-
-        Supports two modes:
-        1. Continuous binning: Use 'bins' parameter for numeric ranges
-        2. Discrete mapping: Use 'value_mapping' parameter for bin-to-values mapping
-
-        Args:
-            phenotype: The phenotype to bin values from
-            bins: List of bin edges for continuous values (e.g., [0, 10, 20, 30])
-                 Default is [0, 10, 20, ..., 100] for backward compatibility
-            value_mapping: Dictionary mapping bin names to lists of values
-                          (e.g., {"Heart Disease": ["I21", "I22", "I23"], "Diabetes": ["E10", "E11"]})
-        """
         super(BinPhenotype, self).__init__(**kwargs)
 
         # Set default bins for backward compatibility if neither parameter is provided

--- a/phenex/phenotypes/measurement_phenotype.py
+++ b/phenex/phenotypes/measurement_phenotype.py
@@ -73,6 +73,7 @@ class MeasurementPhenotype(CodelistPhenotype):
         # Default value of return_date in codelist_phenotype is 'first'. This is not helpful behavior for measurementphenotype as we will perform further operations that require all values. For example, if we want the mean of all values in the post index period, setting return_date = 'first' will return only the values on the first day
         if "return_date" not in kwargs:
             kwargs["return_date"] = "all"
+        kwargs['return_value'] = 'all'
         super(MeasurementPhenotype, self).__init__(
             **kwargs,
         )
@@ -109,7 +110,7 @@ class MeasurementPhenotype(CodelistPhenotype):
         code_table = self._perform_null_value_filtering(code_table)
         code_table = self._perform_nonphysiological_value_filtering(code_table)
         code_table = self._perform_time_filtering(code_table)
-        code_table = self._perform_date_selection(code_table, reduce=False)
+        code_table = self._perform_date_selection(code_table)
         code_table = self._perform_value_aggregation(code_table)
         code_table = self._perform_value_filtering(code_table)
         return select_phenotype_columns(code_table)

--- a/phenex/phenotypes/measurement_phenotype.py
+++ b/phenex/phenotypes/measurement_phenotype.py
@@ -73,7 +73,7 @@ class MeasurementPhenotype(CodelistPhenotype):
         # Default value of return_date in codelist_phenotype is 'first'. This is not helpful behavior for measurementphenotype as we will perform further operations that require all values. For example, if we want the mean of all values in the post index period, setting return_date = 'first' will return only the values on the first day
         if "return_date" not in kwargs:
             kwargs["return_date"] = "all"
-        kwargs['return_value'] = 'all'
+        kwargs["return_value"] = "all"
         super(MeasurementPhenotype, self).__init__(
             **kwargs,
         )

--- a/phenex/test/phenotypes/test_bin_phenotype.py
+++ b/phenex/test/phenotypes/test_bin_phenotype.py
@@ -3,7 +3,9 @@ import pandas as pd
 
 from phenex.phenotypes.age_phenotype import AgePhenotype
 from phenex.phenotypes.bin_phenotype import BinPhenotype
+from phenex.phenotypes.codelist_phenotype import CodelistPhenotype
 from phenex.codelists import LocalCSVCodelistFactory
+from phenex.codelists.codelists import Codelist
 from phenex.filters.date_filter import DateFilter
 from phenex.filters.relative_time_range_filter import RelativeTimeRangeFilter
 from phenex.test.util.dummy.generate_dummy_data import (
@@ -74,5 +76,125 @@ def test_binned_age_phenotype():
     spg.run_tests()
 
 
+class DiscreteBinPhenotypeTestGenerator(PhenotypeTestGenerator):
+    name_space = "discrete_bin"
+    value_datatype = str
+    test_values = True
+
+    def define_input_tables(self):
+        # Use the same dummy data generation as CodelistPhenotype tests
+        df, tt = sdf_and_tt_dummycodes_3variables(
+            code_columnname="CODE",
+            patientid_columnname="PERSON_ID",
+            code_type_columnname="CODE_TYPE",
+            event_date_columnname="EVENT_DATE",
+        )
+
+        # Modify the codes to match our test case
+        # Replace the dummy codes with our diagnosis codes
+        code_mapping = {
+            "c1": "I21",
+            "c2": "I22",
+            "c3": "I23",
+        }
+
+        # Apply the mapping
+        df["CODE"] = df["CODE"].map(lambda x: code_mapping.get(x, x))
+
+        # Add some additional test data
+        additional_rows = [
+            {
+                "PERSON_ID": "P8",
+                "CODE": "E10",
+                "EVENT_DATE": datetime.datetime.strptime("01-01-2022", "%m-%d-%Y"),
+                "CODE_TYPE": "ICD10CM",
+            },
+        ]
+        df_additional = pd.DataFrame(additional_rows)
+        df = pd.concat([df, df_additional], ignore_index=True)
+
+        return [{"name": "CONDITION_OCCURRENCE", "df": df}]
+
+    def define_phenotype_tests(self):
+        # Create a proper Codelist object
+        diagnosis_codelist = Codelist(["I21", "I22", "I23", "E10"], "diagnosis_codes")
+
+        # Create a CodelistPhenotype that returns codes
+        diagnosis_codes = CodelistPhenotype(
+            name="diagnosis_codes",
+            codelist=diagnosis_codelist,
+            domain="CONDITION_OCCURRENCE",
+            return_value="all",
+        )
+
+        # Test discrete binning
+        # Based on the dummy data generation pattern:
+        # P1 has I21, I22, I23 -> when binned: "Acute MI", "Acute MI", "MI Complications"
+        # P2 has I21, I22 -> when binned: "Acute MI", "Acute MI"
+        # P3 has I21, I23 -> when binned: "Acute MI", "MI Complications"
+        # P4 has I21 -> when binned: "Acute MI"
+        # P5 has I22, I23 -> when binned: "Acute MI", "MI Complications"
+        # P6 has I22 -> when binned: "Acute MI"
+        # P7 has I23 -> when binned: "MI Complications"
+        # P8 has E10 -> when binned: "Diabetes"
+
+        # Since return_value="all", we get one row per person per code
+        # We expect multiple rows for some patients
+        t1 = {
+            "name": "discrete_mapping",
+            "persons": [
+                "P1",
+                "P1",
+                "P1",
+                "P2",
+                "P2",
+                "P3",
+                "P3",
+                "P4",
+                "P5",
+                "P5",
+                "P6",
+                "P7",
+                "P8",
+            ],
+            "values": [
+                "Acute MI",
+                "Acute MI",
+                "MI Complications",
+                "Acute MI",
+                "Acute MI",
+                "Acute MI",
+                "MI Complications",
+                "Acute MI",
+                "Acute MI",
+                "MI Complications",
+                "Acute MI",
+                "MI Complications",
+                "Diabetes",
+            ],
+            "phenotype": BinPhenotype(
+                phenotype=diagnosis_codes,
+                value_mapping={
+                    "Acute MI": ["I21", "I22"],
+                    "MI Complications": ["I23"],
+                    "Diabetes": ["E10", "E11"],  # E11 not in data but OK in mapping
+                },
+            ),
+        }
+
+        test_infos = [t1]
+
+        for test_info in test_infos:
+            test_info["phenotype"].name = test_info["name"]
+
+        return test_infos
+
+
+def test_discrete_bin_phenotype():
+    spg = DiscreteBinPhenotypeTestGenerator()
+    spg.run_tests()
+
+
 if __name__ == "__main__":
     test_binned_age_phenotype()
+    test_discrete_bin_phenotype()

--- a/phenex/test/phenotypes/test_codelist_phenotype.py
+++ b/phenex/test/phenotypes/test_codelist_phenotype.py
@@ -1149,15 +1149,6 @@ class CodelistPhenotypeReturnValueTestGenerator(PhenotypeTestGenerator):
                     event_date_2,
                     event_date_2,
                 ],
-                "VALUE": [
-                    10,
-                    20,
-                    30,
-                    40,
-                    50,
-                    60,
-                    70,
-                ],  # Original values (not used when return_value='all')
             }
         )
 

--- a/phenex/test/phenotypes/test_codelist_phenotype.py
+++ b/phenex/test/phenotypes/test_codelist_phenotype.py
@@ -1097,6 +1097,233 @@ def test_categorical_filter_is_null_phenotype():
     tg.run_tests()
 
 
+def test_return_value():
+    tg = CodelistPhenotypeReturnValueTestGenerator()
+    tg.run_tests()
+
+
+def test_return_value_reduced():
+    tg = CodelistPhenotypeReturnValueReducedTestGenerator()
+    tg.run_tests()
+
+
+class CodelistPhenotypeReturnValueTestGenerator(PhenotypeTestGenerator):
+    """Test the return_value parameter functionality"""
+
+    name_space = "clpt_return_value"
+    test_values = True  # Enable value testing
+    test_date = True  # Enable date testing
+    value_datatype = str  # Set value datatype to str since we're returning codes
+
+    def define_input_tables(self):
+        # Create test data with multiple codes on the same date for some patients
+        # This will help test the return_value='all' functionality
+
+        # P1 has 2 different codes on the same date (2022-01-01) - should test return_value='all'
+        # P2 has codes on different dates - should test first/last selection
+        # P3 has 3 different codes on the same date (2022-01-02) - should test return_value='all'
+
+        event_date_1 = datetime.date(2022, 1, 1)
+        event_date_2 = datetime.date(2022, 1, 2)
+        event_date_3 = datetime.date(2022, 1, 3)
+
+        df = pd.DataFrame.from_dict(
+            {
+                "CODE": [
+                    "c1",
+                    "c2",
+                    "c1",
+                    "c3",
+                    "c1",
+                    "c2",
+                    "c3",
+                ],  # Different codes to test return_value
+                "PERSON_ID": ["P1", "P1", "P2", "P2", "P3", "P3", "P3"],
+                "CODE_TYPE": ["ICD10CM"] * 7,
+                "EVENT_DATE": [
+                    event_date_1,
+                    event_date_1,
+                    event_date_1,
+                    event_date_3,
+                    event_date_2,
+                    event_date_2,
+                    event_date_2,
+                ],
+                "VALUE": [
+                    10,
+                    20,
+                    30,
+                    40,
+                    50,
+                    60,
+                    70,
+                ],  # Original values (not used when return_value='all')
+            }
+        )
+
+        return [{"name": "CONDITION_OCCURRENCE", "df": df}]
+
+    def define_phenotype_tests(self):
+        event_date_1 = datetime.date(2022, 1, 1)
+        event_date_2 = datetime.date(2022, 1, 2)
+        event_date_3 = datetime.date(2022, 1, 3)
+
+        # Test 1: return_date='all', return_value='all' - should return all rows with codes as values
+        t1 = {
+            "name": "all_date_all_value",
+            "return_date": "all",
+            "return_value": "all",
+            "persons": ["P1", "P1", "P2", "P2", "P3", "P3", "P3"],  # All original rows
+            "dates": [
+                event_date_1,
+                event_date_1,
+                event_date_1,
+                event_date_3,
+                event_date_2,
+                event_date_2,
+                event_date_2,
+            ],
+            "values": [
+                "c1",
+                "c2",
+                "c1",
+                "c3",
+                "c1",
+                "c2",
+                "c3",
+            ],  # The matching codes as values
+        }
+
+        # Test 2: return_date='first', return_value='all' - should return all codes on first date
+        t2 = {
+            "name": "first_date_all_value",
+            "return_date": "first",
+            "return_value": "all",
+            "persons": [
+                "P2",
+                "P3",
+                "P3",
+                "P3",
+                "P1",
+                "P1",
+            ],  # All rows on first date for each person (order may vary)
+            "dates": [
+                event_date_1,
+                event_date_2,
+                event_date_2,
+                event_date_2,
+                event_date_1,
+                event_date_1,
+            ],  # First dates
+            "values": [
+                "c1",
+                "c1",
+                "c2",
+                "c3",
+                "c1",
+                "c2",
+            ],  # Codes on first date for each person
+        }
+
+        test_infos = [t1, t2]
+
+        # Create phenotypes for each test
+        for test_info in test_infos:
+            name = test_info["name"]
+            return_date = test_info.get("return_date", "first")
+            return_value = test_info.get("return_value", None)
+
+            codelist = Codelist(
+                ["c1", "c2", "c3"]
+            )  # Include all codes in the test data
+
+            test_info["phenotype"] = CodelistPhenotype(
+                name=name,
+                domain="CONDITION_OCCURRENCE",
+                codelist=codelist,
+                return_date=return_date,
+                return_value=return_value,
+            )
+
+        return test_infos
+
+
+class CodelistPhenotypeReturnValueReducedTestGenerator(PhenotypeTestGenerator):
+    """Test the return_value=None parameter functionality (reduced output)"""
+
+    name_space = "clpt_return_value_reduced"
+    test_values = False  # Don't test values since they are null
+    test_date = True  # Enable date testing
+
+    def define_input_tables(self):
+        # Same input data as the main test
+        event_date_1 = datetime.date(2022, 1, 1)
+        event_date_2 = datetime.date(2022, 1, 2)
+        event_date_3 = datetime.date(2022, 1, 3)
+
+        df = pd.DataFrame.from_dict(
+            {
+                "CODE": ["c1", "c1", "c1", "c1", "c1", "c1", "c1"],
+                "PERSON_ID": ["P1", "P1", "P2", "P2", "P3", "P3", "P3"],
+                "CODE_TYPE": ["ICD10CM"] * 7,
+                "EVENT_DATE": [
+                    event_date_1,
+                    event_date_1,
+                    event_date_1,
+                    event_date_3,
+                    event_date_2,
+                    event_date_2,
+                    event_date_2,
+                ],
+                "VALUE": [10, 20, 30, 40, 50, 60, 70],
+            }
+        )
+
+        return [{"name": "CONDITION_OCCURRENCE", "df": df}]
+
+    def define_phenotype_tests(self):
+        event_date_1 = datetime.date(2022, 1, 1)
+        event_date_2 = datetime.date(2022, 1, 2)
+        event_date_3 = datetime.date(2022, 1, 3)
+
+        # Test: return_date='first', return_value=None (default) - should return first date, one row per person
+        t1 = {
+            "name": "first_date_default_value",
+            "return_date": "first",
+            "return_value": None,
+            "persons": [
+                "P3",
+                "P2",
+                "P1",
+            ],  # One row per person on first date (note: order may vary)
+            "dates": [
+                event_date_2,
+                event_date_1,
+                event_date_1,
+            ],  # First date for each person
+        }
+
+        test_infos = [t1]
+
+        # Create phenotypes for each test
+        for test_info in test_infos:
+            name = test_info["name"]
+            return_date = test_info.get("return_date", "first")
+            return_value = test_info.get("return_value", None)
+
+            codelist = Codelist(["c1"])
+
+            test_info["phenotype"] = CodelistPhenotype(
+                name=name,
+                domain="CONDITION_OCCURRENCE",
+                codelist=codelist,
+                return_date=return_date,
+                return_value=return_value,
+            )
+
+        return test_infos
+
+
 if __name__ == "__main__":
     test_categorical_filter_is_null_phenotype()
     test_categorical_filter_logic()
@@ -1106,3 +1333,5 @@ if __name__ == "__main__":
     test_anchor_phenotype()
     test_return_date()
     test_fuzzy_match()
+    test_return_value()
+    test_return_value_reduced()


### PR DESCRIPTION
- **BinPhenotype now works with categorical values** : prior, BinPhenotype only worked on numeric valued phenotypes. Now, BinPhenotype works on non-numerical VALUE columns as well, allowing value mapping of multiple categorical values to user defined bins.
- **CodelistPhenotype now returns matching codes** : prior, CodelistPhenotype only returned person ids and event dates, with all null values. Now it returns a VALUE; this value is the code that resulted in a person fulfilling the phenotype criteria, Thus answering the question 'what code did person x have from codelist y'.
