### PR TITLE
Add DatabaseSampler part of Database option

### DIFF
--- a/docs/api/util/database_sampler.md
+++ b/docs/api/util/database_sampler.md
@@ -40,6 +40,29 @@ print(sampler.describe())
 Every domain that has a `PERSON_ID` column is filtered to the sampled patients;
 domains without `PERSON_ID` are passed through unchanged.
 
+## Using the sampler in a Study
+
+Calling `sample()` by hand is useful for exploration, but the usual pattern is to
+attach the sampler to the `Study`'s `Database`.
+
+```python
+from phenex import Cohort, Database, Study
+from phenex.util import DatabaseSampler
+from phenex.mappers import OMOPDomains
+
+study_db = Database(
+    mapper=OMOPDomains,
+    connector=con,                                   # con: your connector
+    sampler=DatabaseSampler(fraction=0.1, seed=42),  # 10% reproducible sample
+)
+
+cohort_a = Cohort(name="cohort_a", entry_criterion=entry_a, inclusions=inclusions, exclusions=exclusions)
+cohort_b = Cohort(name="cohort_b", entry_criterion=entry_b, inclusions=inclusions, exclusions=exclusions)
+
+study = Study(path="./results", name="my_study_sampled", cohorts=[cohort_a, cohort_b], database=study_db)
+study.execute(overwrite=True, lazy_execution=True)
+```
+
 ## Inspecting the sample
 
 `fetch_person_ids()` executes one database round-trip and loads the sampled IDs

--- a/phenex/core/cohort.py
+++ b/phenex/core/cohort.py
@@ -11,6 +11,7 @@ from phenex.util.serialization.to_dict import to_dict
 from phenex.util import create_logger
 from phenex.filters import DateFilter
 from phenex.core.data_period_filter_node import DataPeriodFilterNode
+from phenex.core.database_sampler_node import DatabaseSamplerNode
 from phenex.core.hstack_node import HStackNode
 from phenex.core.subset_table import SubsetTable
 from phenex.core.inclusions_table_node import InclusionsTableNode
@@ -125,6 +126,7 @@ class Cohort:
         self.index_stage = None
         self.derived_tables_post_entry_stage = None
         self.reporting_stage = None
+        self.sampler_stage = self._build_sampler_stage(self._get_domains())
 
         # special Nodes that Cohort builds (later, in build_stages())
         # need to be able to refer to later to get outputs
@@ -149,6 +151,35 @@ class Cohort:
             f"Cohort '{self.name}' initialized with entry criterion '{self.entry_criterion.name}'"
         )
 
+    def _build_sampler_stage(self, domains: List[str]) -> Optional["NodeGroup"]:
+        """Create the sampler NodeGroup. Returns None when no sampler is configured."""
+        if not (self.database and self.database.sampler):
+            return None
+        _frac = self.database.sampler.fraction
+        _seed = self.database.sampler.seed
+        _frac_tag = f"f{int(_frac * 100)}_s{_seed}"
+        sampler_nodes = [
+            DatabaseSamplerNode(
+                name=f"{self.name}__sampler_{domain}__{_frac_tag}".upper(),
+                domain=domain,
+                sampler=self.database.sampler,
+            )
+            for domain in domains
+        ]
+        return NodeGroup(
+            name=f"{self.name}__sampler_stage__{_frac_tag}".upper(),
+            nodes=sampler_nodes,
+        )
+
+    @property
+    def _table_prefix(self) -> str:
+        """Table name prefix for dest DB — appends frac+seed when a sampler is present so same-name cohorts with different sampler params don't collide."""
+        if self.database is not None and self.database.sampler is not None:
+            frac = int(self.database.sampler.fraction * 100)
+            seed = self.database.sampler.seed
+            return f"{self.name}_frac{frac}_seed{seed}"
+        return self.name
+
     @staticmethod
     def _flatten(items: Optional[List]) -> List:
         """Flatten one level of nesting, so both [p1, p2] and [[p1, p2]] work."""
@@ -162,9 +193,9 @@ class Cohort:
                 result.append(item)
         return result
 
-    def _apply_table_name_prefix(self, phenotypes):
-        """Set _table_name_prefix on phenotypes and their dependencies so get_table_name() works before execute()."""
-        prefix = re.sub(r"[^A-Za-z0-9_]", "_", self.name).upper()
+    def _apply_table_name_prefix(self, phenotypes) -> None:
+        """Set _table_name_prefix on phenotypes and their dependencies."""
+        prefix = re.sub(r"[^A-Za-z0-9_]", "_", self._table_prefix).upper()
         if not isinstance(phenotypes, list):
             phenotypes = [phenotypes]
         for p in phenotypes:
@@ -264,6 +295,11 @@ class Cohort:
                 f"Some required domains are not present in input tables: {missing_domains}. "
                 f"Phenotypes requiring these domains may fail during execution."
             )
+
+        #
+        # Sampler stage: OPTIONAL
+        #
+        self.sampler_stage = self._build_sampler_stage(domains)
 
         #
         # Data period filter stage: OPTIONAL
@@ -572,13 +608,53 @@ class Cohort:
         """
 
         con = self._prepare_database_connector_for_execution(con)
-        tables = self._prepare_tables_for_execution(con, tables)
+        tables = dict(self._prepare_tables_for_execution(con, tables))
 
         self.n_persons_in_source_database = (
             tables["PERSON"].distinct().count().execute()
         )
 
         self.build_stages(tables)
+
+        if self.sampler_stage:
+            logger.info(f"Cohort '{self.name}': executing sampler stage ...")
+            self.sampler_stage.execute(
+                tables=tables,
+                con=con,
+                overwrite=overwrite,
+                n_threads=n_threads,
+                lazy_execution=lazy_execution,
+                table_name_prefix=self._table_prefix,
+            )
+            # If the tables were already cached, we reuse them and skip sample(),
+            # list never gets saved.
+            # Build it again here so fetch_person_ids() always works.
+            sampler = self.database.sampler
+            if sampler._person_ids_expr is None:
+                person_tbl = tables.get("PERSON")
+                if person_tbl is not None:
+                    person_ibis = (
+                        person_tbl.table
+                        if isinstance(person_tbl, PhenexTable)
+                        else person_tbl
+                    )
+                    sampler._person_ids_expr = sampler._sampled_person_ids(person_ibis)
+
+            # Swap in the sampled table for each domain, so the later steps use the smaller
+            # sampled data instead of the full tables.
+            for node in self.sampler_stage.children:
+                if node.table is not None:
+                    original = tables.get(node.domain)
+                    sampled = node.table
+                    if isinstance(original, PhenexTable) and not isinstance(
+                        sampled, PhenexTable
+                    ):
+                        sampled = type(original)(
+                            sampled, name=original.NAME_TABLE, column_mapping={}
+                        )
+                    node.table = sampled
+                    tables[node.domain] = sampled
+            logger.info(f"Cohort '{self.name}': completed sampler stage.")
 
         # Apply data period filter first if specified
         if self.data_period_filter_stage:
@@ -589,13 +665,22 @@ class Cohort:
                 overwrite=overwrite,
                 n_threads=n_threads,
                 lazy_execution=lazy_execution,
-                table_name_prefix=self.name,
+                table_name_prefix=self._table_prefix,
             )
             # Update tables with filtered versions (only when the node actually modified the table;
             # nodes with no relevant date columns return None and the original table is kept)
             for node in self.data_period_filter_stage.children:
                 if node.table is not None:
-                    tables[node.domain] = node.table
+                    original = tables.get(node.domain)
+                    filtered = node.table
+                    if isinstance(original, PhenexTable) and not isinstance(
+                        filtered, PhenexTable
+                    ):
+                        filtered = type(original)(
+                            filtered, name=original.NAME_TABLE, column_mapping={}
+                        )
+                    node.table = filtered
+                    tables[node.domain] = filtered
             logger.info(f"Cohort '{self.name}': completed data period filter stage.")
 
         if self.derived_tables_stage:
@@ -608,7 +693,7 @@ class Cohort:
                 overwrite=overwrite,
                 n_threads=n_threads,
                 lazy_execution=lazy_execution,
-                table_name_prefix=self.name,
+                table_name_prefix=self._table_prefix,
             )
             logger.info(
                 f"Cohort '{self.name}': completed derived tables pre-entry stage."
@@ -624,7 +709,7 @@ class Cohort:
             overwrite=overwrite,
             n_threads=n_threads,
             lazy_execution=lazy_execution,
-            table_name_prefix=self.name,
+            table_name_prefix=self._table_prefix,
         )
         self.subset_tables_entry = tables = self.get_subset_tables_entry(tables)
 
@@ -640,7 +725,7 @@ class Cohort:
                 overwrite=overwrite,
                 n_threads=n_threads,
                 lazy_execution=lazy_execution,
-                table_name_prefix=self.name,
+                table_name_prefix=self._table_prefix,
             )
             logger.info(
                 f"Cohort '{self.name}': completed derived tables post-entry stage."
@@ -662,7 +747,7 @@ class Cohort:
             overwrite=overwrite,
             n_threads=n_threads,
             lazy_execution=lazy_execution,
-            table_name_prefix=self.name,
+            table_name_prefix=self._table_prefix,
         )
         self.table = self.index_table_node.table
 
@@ -691,7 +776,7 @@ class Cohort:
                 overwrite=overwrite,
                 n_threads=n_threads,
                 lazy_execution=lazy_execution,
-                table_name_prefix=self.name,
+                table_name_prefix=self._table_prefix,
             )
 
         return self.index_table

--- a/phenex/core/database.py
+++ b/phenex/core/database.py
@@ -1,6 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 from phenex.util.serialization.to_dict import to_dict
 from phenex.util import create_logger
+from phenex.util.database_sampler import DatabaseSampler
 
 if TYPE_CHECKING:
     from phenex.ibis_connect import (
@@ -32,12 +33,16 @@ class Database:
         data_period: Optional DateFilter to restrict all input data to a specific date range.
                     The input data will be modified to look as if data outside the data_period
                     was never recorded before any phenotypes are computed.
+        sampler: Optional DatabaseSampler to restrict all input data to a reproducible subset
+                 of patients before any phenotypes are computed. Useful for fast iteration
+                 during development against large production databases.
         name: Optional descriptive name for this database configuration.
 
     Attributes:
         connector: The database connector instance.
         mapper: The domains dictionary for table mapping.
         data_period: The date filter for restricting data, if any.
+        sampler: The database sampler for patient sub-sampling, if any.
         name: The descriptive name of this database configuration.
 
     Example:
@@ -71,6 +76,7 @@ class Database:
         ] = None,
         mapper: Optional["DomainsDictionary"] = None,
         data_period: Optional["DateFilter"] = None,
+        sampler: Optional[DatabaseSampler] = None,
         name: Optional[str] = None,
     ):
         """
@@ -80,11 +86,13 @@ class Database:
             connector: Database connector for reading/writing data.
             mapper: DomainsDictionary for mapping tables to PhenEx domains.
             data_period: Optional date filter to restrict input data.
+            sampler: Optional DatabaseSampler to restrict input data to a patient subset.
             name: Optional descriptive name for this database.
         """
         self.connector = connector
         self.mapper = mapper
         self.data_period = data_period
+        self.sampler = sampler
         self.name = name or "unnamed_database"
 
         logger.info(f"Database '{self.name}' initialized")
@@ -188,12 +196,14 @@ class Database:
         connector_type = type(self.connector).__name__ if self.connector else "None"
         mapper_type = type(self.mapper).__name__ if self.mapper else "None"
         data_period_str = str(self.data_period) if self.data_period else "None"
+        sampler_str = repr(self.sampler) if self.sampler else "None"
 
         return (
             f"Database(name='{self.name}', "
             f"connector={connector_type}, "
             f"mapper={mapper_type}, "
-            f"data_period={data_period_str})"
+            f"data_period={data_period_str}, "
+            f"sampler={sampler_str})"
         )
 
     def validate(self) -> None:

--- a/phenex/core/database_sampler_node.py
+++ b/phenex/core/database_sampler_node.py
@@ -1,0 +1,70 @@
+from typing import Dict, Optional, TYPE_CHECKING
+from phenex.node import Node
+from phenex.util.database_sampler import DatabaseSampler
+from phenex.util import create_logger
+
+if TYPE_CHECKING:
+    from phenex.tables import PhenexTable
+
+logger = create_logger(__name__)
+
+
+class DatabaseSamplerNode(Node):
+    """
+    A compute node that filters one domain table to a reproducible patient subset.
+
+    One node is created per domain. All nodes in the sampler_stage share the same
+    DatabaseSampler (same fraction and seed), so they select the same patient subset
+    across all domain tables.
+
+    Including fraction and seed in to_dict() ensures that changing either value
+    invalidates downstream node hashes, forcing re-execution when lazy_execution=True.
+
+    Parameters:
+        name: Unique node identifier (e.g. 'COHORTNAME__SAMPLER_PERSON').
+        domain: Domain table to filter (e.g. 'PERSON', 'CONDITION_OCCURRENCE').
+        sampler: DatabaseSampler defining fraction and seed.
+    """
+
+    def __init__(self, name: str, domain: str, sampler: DatabaseSampler):
+        super().__init__(name=name)
+        self.domain = domain
+        self.sampler = sampler
+
+    def to_dict(self) -> dict:
+        """Return node identity including fraction and seed so hash changes when sampler config changes."""
+        return {
+            "class_name": self.__class__.__name__,
+            "name": self.name,
+            "domain": self.domain,
+            "fraction": self.sampler.fraction,
+            "seed": self.sampler.seed,
+        }
+
+    @property
+    def _skip_cache(self) -> bool:
+        """True for fraction=1.0 which returns None and never writes a dest table."""
+        return self.sampler.fraction == 1.0
+
+    def _execute(self, tables: Dict[str, "PhenexTable"]) -> Optional["PhenexTable"]:
+        """Filter self.domain table to the sampled patient subset. Returns None if either table is missing."""
+        domain_table = tables.get(self.domain)
+        person_table = tables.get("PERSON")
+        if domain_table is None or person_table is None:
+            logger.info(
+                f"DatabaseSamplerNode '{self.name}': skipping domain '{self.domain}' (table missing)"
+            )
+            return None
+        if self.sampler.fraction == 1.0:
+            logger.info(
+                f"DatabaseSamplerNode '{self.name}': fraction=1.0 no-op for domain '{self.domain}'"
+            )
+            return None
+        logger.info(
+            f"DatabaseSamplerNode '{self.name}': sampling domain '{self.domain}' (fraction={self.sampler.fraction}, seed={self.sampler.seed})"
+        )
+        result = self.sampler.sample(
+            {"PERSON": person_table, self.domain: domain_table}
+        )
+        sampled = result.get(self.domain)
+        return sampled

--- a/phenex/node.py
+++ b/phenex/node.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from phenex.util.serialization.to_dict import to_dict
 from phenex.util import create_logger
 from phenex.node_manager import NodeManager
+from phenex.tables import PhenexTable
 import threading
 import queue
 from deepdiff import DeepDiff
@@ -381,14 +382,25 @@ class Node:
             if degree == 0:
                 ready_queue.put(node_name)
 
+        def _restore_phenex_wrapper(materialized, original):
+            # Re-wrap: get_dest_table() strips PhenexTable metadata, restore the original subclass.
+            if isinstance(original, PhenexTable) and not isinstance(
+                materialized, PhenexTable
+            ):
+                return type(original)(
+                    materialized, name=original.NAME_TABLE, column_mapping={}
+                )
+            return materialized
+
         def _run_and_materialise(node, node_name):
             """Execute *node*, materialise the result, record timing, and update the run hash."""
             db_name = node.get_table_name(table_name_prefix)
             node.lastexecution_start_time = datetime.now()
             table = node._execute(tables)
             if table is not None:
+                original = table
                 con.create_table(table, db_name, overwrite=overwrite)
-                table = con.get_dest_table(db_name)
+                table = _restore_phenex_wrapper(con.get_dest_table(db_name), original)
             node.lastexecution_end_time = datetime.now()
             node.lastexecution_duration = (
                 node.lastexecution_end_time - node.lastexecution_start_time
@@ -424,7 +436,16 @@ class Node:
                                 "A DatabaseConnector is required for lazy execution."
                             )
 
-                        if Node._node_manager.should_rerun(node, con):
+                        # Sampler nodes write no dest table (the SAMPLER_STAGE group returns
+                        # None; a fraction=1.0 node is a no-op via _skip_cache). Skip the cache
+                        # for them — with no table to look up they would perpetually MISS.
+                        is_sampler_group = (
+                            isinstance(node, NodeGroup)
+                            and "SAMPLER_STAGE" in node.name.upper()
+                        )
+                        if is_sampler_group or getattr(node, "_skip_cache", False):
+                            table = node._execute(tables)
+                        elif Node._node_manager.should_rerun(node, con):
                             table = _run_and_materialise(node, node_name)
                         else:
                             db_name = node.get_table_name(table_name_prefix)
@@ -444,6 +465,7 @@ class Node:
                         if (
                             con and table is not None
                         ):  # Only create table if _execute returns something
+                            original = table
                             db_name = node.get_table_name(table_name_prefix)
                             logger.info(
                                 f"Thread {threading.current_thread().name}: materializing '{node_name}' to database ..."
@@ -454,7 +476,9 @@ class Node:
                                 f"Thread {threading.current_thread().name}: materialized '{node_name}' "
                                 f"in {(datetime.now() - _t_mat).total_seconds():.3f}s"
                             )
-                            table = con.get_dest_table(db_name)
+                            table = _restore_phenex_wrapper(
+                                con.get_dest_table(db_name), original
+                            )
 
                         node.lastexecution_end_time = datetime.now()
                         node.lastexecution_duration = (
@@ -650,6 +674,9 @@ class NodeGroup(Node):
 
     def __init__(self, name: str, nodes: List[Node]):
         super(NodeGroup, self).__init__(name=name)
+        # Stored (not just added as children) so to_dict()/hash see the nodes —
+        # this is what invalidates the sampler-stage hash on fraction/seed change.
+        self.nodes = nodes
         self.add_children(nodes)
 
     def _execute(self, tables: Dict[str, Table] = None) -> Table:

--- a/phenex/test/serialization/test_serialization.py
+++ b/phenex/test/serialization/test_serialization.py
@@ -273,6 +273,33 @@ def create_three_phenotypes():
     return c1, c2, c3
 
 
+# ── to_dict()
+
+
+def _cat_to_dict(values):
+    """to_dict() of a CategoricalFilter whose allowed_values is the given list."""
+    return CategoricalFilter(column_name="x", allowed_values=values).to_dict()
+
+
+def test_to_dict_sorts_scalar_list_deterministically():
+    """Same scalars in different order → identical, sorted to_dict."""
+    assert _cat_to_dict(["b", "a", "c"]) == _cat_to_dict(["a", "b", "c"])
+    assert _cat_to_dict(["b", "a", "c"])["allowed_values"] == ["a", "b", "c"]
+
+
+def test_to_dict_sorts_dict_list_deterministically():
+    """Lists of dicts are ordered by their JSON form, so order-in == order-out."""
+    assert _cat_to_dict([{"b": 2}, {"a": 1}]) == _cat_to_dict([{"a": 1}, {"b": 2}])
+    assert _cat_to_dict([{"b": 2}, {"a": 1}])["allowed_values"] == [{"a": 1}, {"b": 2}]
+
+
+def test_to_dict_unsortable_list_falls_back_without_crashing():
+    """A non-JSON-serializable item (a set inside a dict) hits the
+    except (TypeError, ValueError) branch and preserves the original order."""
+    result = _cat_to_dict([{"a": {1, 2}}, {"b": 3}])
+    assert result["allowed_values"] == [{"a": {1, 2}}, {"b": 3}]  # preserved, no crash
+
+
 if __name__ == "__main__":
     test_cohort_serialization()
     test_CodelistPhenotype()
@@ -286,3 +313,6 @@ if __name__ == "__main__":
     test_ScorePhenotype()
     test_ArithmeticPhenotype()
     test_LogicPhenotype()
+    test_to_dict_sorts_dict_list_deterministically()
+    test_to_dict_sorts_scalar_list_deterministically()
+    test_to_dict_unsortable_list_falls_back_without_crashing()

--- a/phenex/test/test_database.py
+++ b/phenex/test/test_database.py
@@ -6,6 +6,7 @@ import pytest
 from phenex.core.database import Database
 from phenex.filters import After, Before
 from phenex.mappers import OMOPDomains
+from phenex.util.database_sampler import DatabaseSampler
 from datetime import date
 import json
 
@@ -242,9 +243,37 @@ def test_database_with_only_data_period():
     db.validate()
 
 
+def test_database_sampler_default_is_none():
+    """sampler defaults to None when not provided — backward-compat contract."""
+    db = Database()
+    assert db.sampler is None
+
+
+def test_database_repr_surfaces_sampler_config():
+    """repr() must surface the sampler's fraction and seed when one is set.
+
+    (Regression: Database.repr() interpolated repr(sampler), which was the default
+    <object at 0x..> until DatabaseSampler.__repr__ was added — the config was invisible.)
+    """
+    db = Database(sampler=DatabaseSampler(fraction=0.25, seed=7), name="sampler_db")
+    r = repr(db)
+    assert "fraction=0.25" in r and "seed=7" in r, f"repr() hides sampler config: {r}"
+
+
+def test_database_repr_without_sampler_shows_none():
+    """repr() is safe when sampler is None and says so explicitly."""
+    db = Database(name="no_sampler_db")
+    r = repr(db)
+    assert "no_sampler_db" in r
+    assert "sampler=None" in r
+
+
 if __name__ == "__main__":
     test_database_with_only_data_period()
     test_database_default_name()
     test_snowflake_connector_serialization()
     test_postgres_connector_serialization()
+    test_database_sampler_default_is_none()
+    test_database_repr_surfaces_sampler_config()
+    test_database_repr_without_sampler_shows_none()
     # pytest.main([__file__])

--- a/phenex/test/test_database_sampler_node.py
+++ b/phenex/test/test_database_sampler_node.py
@@ -1,0 +1,202 @@
+"""
+Tests for DatabaseSamplerNode.
+"""
+
+import datetime
+
+import ibis
+import pandas as pd
+import pytest
+
+from phenex.core.database_sampler_node import DatabaseSamplerNode
+from phenex.node import NodeGroup
+from phenex.tables import CodeTable, PhenexPersonTable
+from phenex.util.database_sampler import DatabaseSampler
+
+_PERSON_IDS = [1001, 2002, 3003, 4004, 5005, 6006, 7007, 8008, 9009, 1010]
+_N = len(_PERSON_IDS)
+
+
+@pytest.fixture
+def sampler_half():
+    return DatabaseSampler(fraction=0.5, seed=42)
+
+
+@pytest.fixture
+def tables():
+    """10-patient PERSON + CONDITION_OCCURRENCE dataset as ibis memtables."""
+    person = PhenexPersonTable(ibis.memtable(pd.DataFrame({"PERSON_ID": _PERSON_IDS})))
+    cond = CodeTable(
+        ibis.memtable(
+            pd.DataFrame(
+                {
+                    "PERSON_ID": _PERSON_IDS,
+                    "EVENT_DATE": [datetime.date(2020, 1, 1)] * _N,
+                    "CODE": ["X"] * _N,
+                }
+            )
+        )
+    )
+    return {"PERSON": person, "CONDITION_OCCURRENCE": cond}
+
+
+# to_dict()
+
+
+def test_to_dict_contains_required_keys(sampler_half):
+    node = DatabaseSamplerNode(
+        name="TEST__SAMPLER_PERSON", domain="PERSON", sampler=sampler_half
+    )
+    d = node.to_dict()
+    for key in ("class_name", "name", "domain", "fraction", "seed"):
+        assert key in d, f"Missing key: {key}"
+
+
+def test_to_dict_values_match_inputs(sampler_half):
+    node = DatabaseSamplerNode(
+        name="MY_NODE", domain="CONDITION_OCCURRENCE", sampler=sampler_half
+    )
+    d = node.to_dict()
+    assert d["class_name"] == "DatabaseSamplerNode"
+    assert d["name"] == "MY_NODE"
+    assert d["domain"] == "CONDITION_OCCURRENCE"
+    assert d["fraction"] == 0.5
+    assert d["seed"] == 42
+
+
+# ── hash()
+
+
+def test_hash_changes_when_fraction_changes():
+    node_a = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.1, seed=42))
+    node_b = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.2, seed=42))
+    assert hash(node_a) != hash(node_b)
+
+
+def test_hash_changes_when_seed_changes():
+    node_a = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.5, seed=7))
+    node_b = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.5, seed=17))
+    assert hash(node_a) != hash(node_b)
+
+
+def test_hash_is_deterministic():
+    node_a = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.5, seed=42))
+    node_b = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.5, seed=42))
+    assert hash(node_a) == hash(node_b)
+
+
+def test_hash_changes_when_domain_changes():
+    node_a = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.5, seed=42))
+    node_b = DatabaseSamplerNode(
+        "N", "CONDITION_OCCURRENCE", DatabaseSampler(fraction=0.5, seed=42)
+    )
+    assert hash(node_a) != hash(node_b)
+
+
+def test_hash_changes_when_name_changes():
+    node_a = DatabaseSamplerNode(
+        "NODE_A", "PERSON", DatabaseSampler(fraction=0.5, seed=42)
+    )
+    node_b = DatabaseSamplerNode(
+        "NODE_B", "PERSON", DatabaseSampler(fraction=0.5, seed=42)
+    )
+    assert hash(node_a) != hash(node_b)
+
+
+# ── _execute()
+
+
+def test_execute_returns_none_when_domain_missing(sampler_half, tables):
+    node = DatabaseSamplerNode("N", "DRUG_EXPOSURE", sampler_half)
+    assert node._execute(tables) is None
+
+
+def test_execute_returns_none_when_person_missing(sampler_half, tables):
+    tables_no_person = {"CONDITION_OCCURRENCE": tables["CONDITION_OCCURRENCE"]}
+    node = DatabaseSamplerNode("N", "CONDITION_OCCURRENCE", sampler_half)
+    assert node._execute(tables_no_person) is None
+
+
+def test_execute_returns_none_when_domain_is_none(sampler_half, tables):
+    tables_with_none = dict(tables)
+    tables_with_none["DRUG_EXPOSURE"] = None
+    node = DatabaseSamplerNode("N", "DRUG_EXPOSURE", sampler_half)
+    assert node._execute(tables_with_none) is None
+
+
+def test_execute_fraction_one_is_noop(tables):
+    # fraction=1.0 keeps every patient, so the node is a no-op
+    node = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=1.0))
+    assert node._skip_cache is True
+    assert node._execute(tables) is None
+
+
+def test_skip_cache_only_true_for_fraction_one():
+    # Only fraction=1.0 skips the cache (it writes no table)
+    assert (
+        DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=1.0))._skip_cache
+        is True
+    )
+    assert (
+        DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.0))._skip_cache
+        is False
+    )
+    assert (
+        DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.1))._skip_cache
+        is False
+    )
+
+
+def test_execute_fraction_zero_returns_empty(tables):
+    node = DatabaseSamplerNode("N", "PERSON", DatabaseSampler(fraction=0.0))
+    result = node._execute(tables)
+    assert result is not None
+    assert result.table.count().execute() == 0
+
+
+def test_execute_condition_filtered_to_same_patients_as_person(sampler_half, tables):
+    person_node = DatabaseSamplerNode("N_PERSON", "PERSON", sampler_half)
+    cond_node = DatabaseSamplerNode("N_COND", "CONDITION_OCCURRENCE", sampler_half)
+
+    person_result = person_node._execute(tables)
+    cond_result = cond_node._execute(tables)
+
+    person_ids = set(
+        person_result.table.select("PERSON_ID").execute()["PERSON_ID"].tolist()
+    )
+    cond_ids = set(
+        cond_result.table.select("PERSON_ID").execute()["PERSON_ID"].tolist()
+    )
+    assert cond_ids <= person_ids
+
+
+def test_execute_preserves_phenex_table_subclass(sampler_half, tables):
+    person_node = DatabaseSamplerNode("N_PERSON", "PERSON", sampler_half)
+    cond_node = DatabaseSamplerNode("N_COND", "CONDITION_OCCURRENCE", sampler_half)
+
+    assert type(person_node._execute(tables)) is type(tables["PERSON"])
+    assert type(cond_node._execute(tables)) is type(tables["CONDITION_OCCURRENCE"])
+
+
+def test_execute_result_has_correct_columns(sampler_half, tables):
+    """Filtered table must have the same columns as the original domain."""
+    node = DatabaseSamplerNode("N", "CONDITION_OCCURRENCE", sampler_half)
+    result = node._execute(tables)
+    assert set(result.table.columns) == set(
+        tables["CONDITION_OCCURRENCE"].table.columns
+    )
+
+
+def test_execute_person_domain_returns_partial_sample(tables):
+    node = DatabaseSamplerNode(
+        "N_PERSON", "PERSON", DatabaseSampler(fraction=0.5, seed=42)
+    )
+    result = node._execute(tables)
+
+    assert result is not None
+    count = result.table.count().execute()
+    assert 0 < count < _N, f"Expected partial sample, got {count}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/phenex/test/test_node.py
+++ b/phenex/test/test_node.py
@@ -690,6 +690,39 @@ class TestPhenexNodeGroup:
         assert child.executed
         assert parent.executed
 
+    def test_hash_changes_when_child_nodes_change(self):
+        """NodeGroup hash must reflect its children — regression for missing self.nodes = nodes."""
+        node_a = ConcreteNode("sampler_frac10")
+        node_b = ConcreteNode("sampler_frac20")
+
+        grp1 = NodeGroup("sampler_stage", [node_a])
+        grp2 = NodeGroup("sampler_stage", [node_b])
+
+        assert hash(grp1) != hash(grp2)
+
+    def test_hash_changes_when_sampler_fraction_changes(self):
+        """NodeGroup hash must change when DatabaseSamplerNode children have different fraction — direct regression test."""
+        from phenex.core.database_sampler_node import DatabaseSamplerNode
+        from phenex.util.database_sampler import DatabaseSampler
+
+        node_10 = DatabaseSamplerNode(
+            name="stage__sampler_person",
+            domain="person",
+            sampler=DatabaseSampler(fraction=0.1, seed=42),
+        )
+        node_20 = DatabaseSamplerNode(
+            name="stage__sampler_person_b",
+            domain="person",
+            sampler=DatabaseSampler(fraction=0.2, seed=42),
+        )
+
+        grp1 = NodeGroup("sampler_stage", [node_10])
+        grp2 = NodeGroup("sampler_stage", [node_20])
+
+        assert hash(grp1) != hash(
+            grp2
+        ), "NodeGroup hash must change when child fraction changes"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/phenex/test/util/test_database_sampler.py
+++ b/phenex/test/util/test_database_sampler.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 from typing import Any
 
 import ibis
@@ -182,6 +183,121 @@ class DatabaseSamplerTestGenerator(PhenotypeTestGenerator):
                 os.makedirs(_path)
 
 
+# Golden test
+
+
+class DatabaseSamplerGoldenTestGenerator(DatabaseSamplerTestGenerator):
+    """Generator-idiom golden test: declares expected PERSON_IDs, runs the sampler,
+    writes diffable expected/ vs result/ artifacts, and ASSERTS computed == golden."""
+
+    _GOLDEN_IDS = [f"P{i}" for i in range(20)]
+
+    def __init__(self) -> None:
+        super().__init__(person_ids=self._GOLDEN_IDS, name_space="dbs_golden")
+
+    def define_phenotype_tests(self):
+        # expected_person_ids
+        return [
+            {
+                "name": "half_seed42",
+                "fraction": 0.5,
+                "seed": 42,
+                "expected_person_ids": [
+                    "P0",
+                    "P2",
+                    "P4",
+                    "P8",
+                    "P9",
+                    "P10",
+                    "P11",
+                    "P15",
+                    "P16",
+                    "P17",
+                    "P19",
+                ],
+            },
+            {
+                "name": "tenth_seed42",
+                "fraction": 0.1,
+                "seed": 42,
+                "expected_person_ids": ["P0", "P8"],
+            },
+            {
+                "name": "half_seed99",
+                "fraction": 0.5,
+                "seed": 99,
+                "expected_person_ids": [
+                    "P3",
+                    "P4",
+                    "P6",
+                    "P7",
+                    "P9",
+                    "P10",
+                    "P11",
+                    "P12",
+                    "P13",
+                    "P14",
+                    "P15",
+                    "P17",
+                    "P18",
+                ],
+            },
+        ]
+
+    def _run_tests(self):
+        """Run each scenario; write golden→expected/ and computed→result/; assert equal."""
+
+        def _key(pid: str) -> int:
+            return int(pid[1:])  # 'P0','P2',...
+
+        for scenario in self.define_phenotype_tests():
+            sampler = DatabaseSampler(
+                fraction=scenario["fraction"], seed=scenario["seed"]
+            )
+            sampled = sampler.sample(self.domains)
+
+            golden = sorted(scenario["expected_person_ids"], key=_key)
+            computed = sorted(
+                sampled["PERSON"]
+                .table.select("PERSON_ID")
+                .execute()["PERSON_ID"]
+                .tolist(),
+                key=_key,
+            )
+
+            stem = f"{self.name_space}_{scenario['name']}"
+            expected_path = os.path.join(self.dirpaths["expected"], stem + ".csv")
+            result_path = os.path.join(self.dirpaths["result"], stem + ".csv")
+            pd.DataFrame({"PERSON_ID": golden}).to_csv(expected_path, index=False)
+            pd.DataFrame({"PERSON_ID": computed}).to_csv(result_path, index=False)
+
+            assert computed == golden, (
+                f"Sampler selection changed for '{scenario['name']}' "
+                f"(fraction={scenario['fraction']}, seed={scenario['seed']}): "
+                f"expected {golden}, got {computed}.\n"
+                f"  diff: {expected_path}\n        {result_path}"
+            )
+
+            # Cross-domain: CONDITION_OCCURRENCE must contain exactly the golden patients
+            # (each patient has one condition row in this fixture).
+            cond_ids = set(
+                sampled["CONDITION_OCCURRENCE"]
+                .table.select("PERSON_ID")
+                .execute()["PERSON_ID"]
+                .tolist()
+            )
+            assert cond_ids == set(golden), (
+                f"'{scenario['name']}': condition-table patients "
+                f"{sorted(cond_ids, key=_key)} != sampled patients {golden}"
+            )
+
+
+def test_golden_sampler_selection_matches_committed_expected():
+    """Client-idiom golden test: sampler must pick exactly the committed PERSON_IDs,
+    and the run produces diffable expected/ vs result/ artifacts for review."""
+    DatabaseSamplerGoldenTestGenerator().run_tests()
+
+
 @pytest.fixture(scope="module")
 def tables_20() -> dict[str, Any]:
     """20-patient PERSON + CONDITION_OCCURRENCE dataset via DatabaseSamplerTestGenerator."""
@@ -230,6 +346,15 @@ def omop_100() -> dict[str, Any]:
     return DomainsMocker(
         OMOPDomains, n_patients=100, random_seed=89
     ).get_mapped_tables()
+
+
+@pytest.fixture(scope="module")
+def person_1000() -> dict[str, Any]:
+    """1000-patient PERSON-only dataset for statistical fraction-calibration tests."""
+    ids = list(range(100_000, 101_000))
+    return {
+        "PERSON": PhenexPersonTable(ibis.memtable(pd.DataFrame({"PERSON_ID": ids})))
+    }
 
 
 # Construction and validation
@@ -352,21 +477,38 @@ def test_fraction_zero_returns_empty_domains(tables_20: dict[str, Any]) -> None:
     assert result["CONDITION_OCCURRENCE"].table.count().execute() == 0
 
 
-def test_condition_rows_only_for_sampled_patients() -> None:
-    """After sampling, no domain contains rows for patients not in PERSON.
+def test_fraction_zero_short_circuits_no_hash_computed(
+    tables_20: dict[str, Any]
+) -> None:
+    """fraction=0.0 short-circuits: _person_ids_expr is set (to empty) but no hash filter runs."""
+    sampler = DatabaseSampler(fraction=0.0)
+    result = sampler.sample(tables_20)
+    assert sampler._person_ids_expr is not None
+    assert result["PERSON"].table.count().execute() == 0
+    assert result["CONDITION_OCCURRENCE"].table.count().execute() == 0
 
-    CONDITION_OCCURRENCE has extra rows for patients 6, 7, 8 who are NOT in PERSON.
-    After fraction=1.0 sampling (keep all PERSON rows), those orphan rows
-    must be dropped because the INNER JOIN on PERSON_ID removes them.
-    """
+
+def test_fraction_one_short_circuits_no_join_applied(tables_20: dict[str, Any]) -> None:
+    """fraction=1.0 short-circuits: sample() returns the original domain objects unchanged."""
+    sampler = DatabaseSampler(fraction=1.0)
+    result = sampler.sample(tables_20)
+    assert sampler._person_ids_expr is not None
+    for key, domain in tables_20.items():
+        assert (
+            result[key] is domain
+        ), f"fraction=1.0 must return original objects unchanged; '{key}' was replaced"
+
+
+def test_fraction_one_preserves_orphan_domain_records() -> None:
+    """fraction=1.0 is a true no-op — domain rows for patients not in PERSON are kept."""
     person_ids = [1, 2, 3, 4, 5]
-    extra_ids = [6, 7, 8]
+    orphan_ids = [6, 7, 8]
     person = PhenexPersonTable(ibis.memtable(pd.DataFrame({"PERSON_ID": person_ids})))
     cond = CodeTable(
         ibis.memtable(
             pd.DataFrame(
                 {
-                    "PERSON_ID": person_ids + extra_ids,
+                    "PERSON_ID": person_ids + orphan_ids,
                     "EVENT_DATE": [datetime.date(2020, 1, 1)] * 8,
                     "CODE": ["X"] * 8,
                 }
@@ -376,7 +518,39 @@ def test_condition_rows_only_for_sampled_patients() -> None:
     tables = {"PERSON": person, "CONDITION_OCCURRENCE": cond}
 
     result = DatabaseSampler(fraction=1.0).sample(tables)
-    assert result["CONDITION_OCCURRENCE"].table.count().execute() == 5
+    assert (
+        result["CONDITION_OCCURRENCE"].table.count().execute() == 8
+    ), "fraction=1.0 must not drop orphan domain records — it is a no-op"
+
+
+def test_condition_rows_only_for_sampled_patients() -> None:
+    """After partial sampling, no domain contains rows for patients not in the sampled PERSON set."""
+    person_ids = [1, 2, 3, 4, 5]
+    orphan_ids = [6, 7, 8]
+    person = PhenexPersonTable(ibis.memtable(pd.DataFrame({"PERSON_ID": person_ids})))
+    cond = CodeTable(
+        ibis.memtable(
+            pd.DataFrame(
+                {
+                    "PERSON_ID": person_ids + orphan_ids,
+                    "EVENT_DATE": [datetime.date(2020, 1, 1)] * 8,
+                    "CODE": ["X"] * 8,
+                }
+            )
+        )
+    )
+    tables = {"PERSON": person, "CONDITION_OCCURRENCE": cond}
+
+    result = DatabaseSampler(fraction=0.5, seed=42).sample(tables)
+    result_ids = set(
+        result["CONDITION_OCCURRENCE"]
+        .table.select("PERSON_ID")
+        .execute()["PERSON_ID"]
+        .tolist()
+    )
+    assert result_ids.isdisjoint(
+        set(orphan_ids)
+    ), f"Orphan patients {result_ids & set(orphan_ids)} leaked into domain result"
 
 
 def test_sample_missing_person_raises(tables_20: dict[str, Any]) -> None:
@@ -411,6 +585,22 @@ def test_sample_twice_resets_fetch_state(tables_20: dict[str, Any]) -> None:
     sampler.sample(tables_20)
     assert sampler.person_ids is None
     assert sampler.person_id_count is None
+
+
+def test_person_ids_expr_correct_after_n_sample_calls(
+    tables_20: dict[str, Any]
+) -> None:
+    """fetch_person_ids() returns the correct patient set regardless of call order."""
+    sampler = DatabaseSampler(fraction=1.0)
+
+    for _ in range(len(tables_20)):
+        sampler.sample(tables_20)
+        assert sampler._person_ids_expr is not None
+        assert sampler.person_ids is None  # reset on every call
+
+    ids = sampler.fetch_person_ids()
+    assert sampler.person_id_count == 20
+    assert set(ids) == set(_INT_PERSON_IDS_20)
 
 
 def test_filtered_domain_contains_only_sampled_patient_rows(
@@ -463,6 +653,7 @@ def test_sample_passes_through_domain_without_person_id(
     tables["CONCEPT"] = concept
     result = DatabaseSampler(fraction=0.5).sample(tables)
     assert result["CONCEPT"].table.count().execute() == 3
+    assert result["CONCEPT"] is concept  # passthrough must return the original object
 
 
 def test_sample_sets_person_ids_expr(tables_20: dict[str, Any]) -> None:
@@ -525,34 +716,6 @@ def test_fetch_called_twice_returns_same_result(tables_10: dict[str, Any]) -> No
 # describe()
 
 
-def test_describe_returns_string() -> None:
-    assert isinstance(DatabaseSampler(fraction=0.1).describe(), str)
-
-
-def test_describe_before_sample_shows_not_sampled() -> None:
-    desc = DatabaseSampler(fraction=0.1).describe()
-    assert "no -- call .sample() first" in desc
-
-
-def test_describe_after_sample_shows_sampled(tables_20: dict[str, Any]) -> None:
-    sampler = DatabaseSampler(fraction=0.1)
-    sampler.sample(tables_20)
-    assert "yes -- call fetch_person_ids() to inspect" in sampler.describe()
-
-
-def test_describe_before_fetch_hides_patient_count(tables_20: dict[str, Any]) -> None:
-    sampler = DatabaseSampler(fraction=0.1)
-    sampler.sample(tables_20)
-    assert "call .fetch_person_ids() to load" in sampler.describe()
-
-
-def test_describe_after_fetch_shows_patient_count(tables_10: dict[str, Any]) -> None:
-    sampler = DatabaseSampler(fraction=1.0)
-    sampler.sample(tables_10)
-    sampler.fetch_person_ids()
-    assert "10" in sampler.describe()
-
-
 def test_describe_contains_fraction_seed_denom_and_filter() -> None:
     """describe() must show fraction, seed, denom, and the string-concat filter formula."""
     sampler = DatabaseSampler(fraction=0.1, seed=7)
@@ -564,10 +727,26 @@ def test_describe_contains_fraction_seed_denom_and_filter() -> None:
 
 
 def test_describe_fraction_zero_shows_empty_filter() -> None:
-    """describe() with fraction=0.0 uses the empty-sample branch (no hash formula)."""
+    """describe() with fraction=0.0 uses the empty-sample branch."""
     desc = DatabaseSampler(fraction=0.0).describe()
     assert "always empty" in desc
     assert "denom      : 0" in desc
+
+
+def test_describe_fraction_one_shows_keep_all_filter() -> None:
+    """describe() with fraction=1.0 uses the keep-all branch."""
+    desc = DatabaseSampler(fraction=1.0).describe()
+    assert "keep all" in desc
+    assert "hash skipped" in desc
+    assert "denom      : 1" in desc
+
+
+def test_repr_shows_fraction_and_seed() -> None:
+    """repr() surfaces the config that defines the sample."""
+    assert (
+        repr(DatabaseSampler(fraction=0.1, seed=42))
+        == "DatabaseSampler(fraction=0.1, seed=42)"
+    )
 
 
 def test_describe_is_safe_at_every_lifecycle_stage(tables_20: dict[str, Any]) -> None:
@@ -595,70 +774,71 @@ def test_string_person_ids_are_supported(string_tables_20: dict[str, Any]) -> No
 # Integration — determinism, seed independence, multi-domain consistency
 
 
-def test_same_fraction_seed_is_deterministic(omop_100: dict[str, Any]) -> None:
+@pytest.mark.parametrize("seed", [42, 0, -1, -99999, sys.maxsize])
+def test_sample_is_deterministic(tables_20: dict[str, Any], seed: int) -> None:
     """Same fraction + seed always returns the exact same patients."""
-    r1 = DatabaseSampler(fraction=0.1, seed=42).sample(omop_100)
-    r2 = DatabaseSampler(fraction=0.1, seed=42).sample(omop_100)
-    ids1 = sorted(
-        r1["PERSON"].table.select("PERSON_ID").execute()["PERSON_ID"].tolist()
-    )
-    ids2 = sorted(
-        r2["PERSON"].table.select("PERSON_ID").execute()["PERSON_ID"].tolist()
-    )
-    assert ids1 == ids2
+
+    def _ids() -> list[Any]:
+        return sorted(
+            DatabaseSampler(fraction=0.5, seed=seed)
+            .sample(tables_20)["PERSON"]
+            .table.select("PERSON_ID")
+            .execute()["PERSON_ID"]
+            .tolist()
+        )
+
+    assert _ids() == _ids()
 
 
-def test_different_seeds_produce_different_cohorts(omop_100: dict[str, Any]) -> None:
+@pytest.mark.parametrize(
+    "seed_a, seed_b",
+    [(7, 17), (42, 52), (0, 1), (-42, 42)],
+)
+def test_different_seeds_produce_different_cohorts(
+    omop_100: dict[str, Any], seed_a: int, seed_b: int
+) -> None:
     """Different seeds produce different patient sets."""
-    for seed_a, seed_b in [(7, 17), (42, 52)]:
-        ids_a = set(
-            DatabaseSampler(fraction=0.1, seed=seed_a)
-            .sample(omop_100)["PERSON"]
-            .table.select("PERSON_ID")
-            .execute()["PERSON_ID"]
-            .tolist()
-        )
-        ids_b = set(
-            DatabaseSampler(fraction=0.1, seed=seed_b)
-            .sample(omop_100)["PERSON"]
-            .table.select("PERSON_ID")
-            .execute()["PERSON_ID"]
-            .tolist()
-        )
-        assert (
-            ids_a != ids_b
-        ), f"seed={seed_a} and seed={seed_b} returned the same patients."
-
-
-def test_seed_zero_and_seed_one_are_different_cohorts(omop_100: dict[str, Any]) -> None:
-    """seed=0 and seed=1 must produce different cohorts.
-
-    seed=0 appends '0' to each stringified PERSON_ID before hashing.
-    seed=1 appends '1', producing different hash inputs and a distinct cohort.
-    """
-    ids_0 = set(
-        DatabaseSampler(fraction=0.1, seed=0)
+    ids_a = set(
+        DatabaseSampler(fraction=0.1, seed=seed_a)
         .sample(omop_100)["PERSON"]
         .table.select("PERSON_ID")
         .execute()["PERSON_ID"]
         .tolist()
     )
-    ids_1 = set(
-        DatabaseSampler(fraction=0.1, seed=1)
+    ids_b = set(
+        DatabaseSampler(fraction=0.1, seed=seed_b)
         .sample(omop_100)["PERSON"]
         .table.select("PERSON_ID")
         .execute()["PERSON_ID"]
         .tolist()
     )
-    assert ids_0 != ids_1
+    assert (
+        ids_a != ids_b
+    ), f"seed={seed_a} and seed={seed_b} returned the same patients."
+
+
+@pytest.mark.parametrize("fraction", [0.1, 0.25, 0.5])
+def test_sample_fraction_is_calibrated(
+    person_1000: dict[str, Any], fraction: float
+) -> None:
+    """The sampler actually samples fraction of patients on a large N."""
+    n = person_1000["PERSON"].table.count().execute()
+    count = (
+        DatabaseSampler(fraction=fraction, seed=42)
+        .sample(person_1000)["PERSON"]
+        .table.count()
+        .execute()
+    )
+    expected = fraction * n
+    rel_err = abs(count - expected) / expected
+    assert rel_err < 0.35, (
+        f"fraction={fraction} on N={n} selected {count} patients "
+        f"(expected ≈{expected:.0f}, relative error {rel_err:.0%} exceeds 35% tolerance)"
+    )
 
 
 def test_all_domains_filtered_to_same_patient_set(omop_100: dict[str, Any]) -> None:
-    """Every domain in the result contains only rows belonging to sampled patients.
-
-    The INNER JOIN on PERSON_ID guarantees this automatically. This test
-    verifies the guarantee holds across all 14 OMOP domains.
-    """
+    """Every domain in the result contains only rows belonging to sampled patients."""
     result = DatabaseSampler(fraction=0.1, seed=42).sample(omop_100)
     ref_ids = set(
         result["PERSON"].table.select("PERSON_ID").execute()["PERSON_ID"].tolist()
@@ -756,6 +936,89 @@ def test_adding_patients_does_not_change_existing_sample() -> None:
     )
 
     assert ids_base <= ids_ext
+
+
+# to_dict()
+
+
+def test_to_dict_contains_required_keys() -> None:
+    """to_dict() must return exactly class_name, fraction, seed."""
+    d = DatabaseSampler(fraction=0.25, seed=7).to_dict()
+    assert set(d.keys()) == {"class_name", "fraction", "seed"}
+
+
+def test_to_dict_values_match_inputs() -> None:
+    d = DatabaseSampler(fraction=0.25, seed=7).to_dict()
+    assert d["class_name"] == "DatabaseSampler"
+    assert d["fraction"] == 0.25
+    assert d["seed"] == 7
+
+
+def test_to_dict_is_json_serializable() -> None:
+    """All three values are JSON primitives, json.dumps must not raise.
+
+    fraction=0.0 is included alongside a normal fraction because 0.0 is the only
+    value that takes a different construction branch (denom=0), both must serialize.
+    """
+    import json
+
+    for frac in (0.1, 0.0):
+        d = DatabaseSampler(fraction=frac, seed=42).to_dict()
+        serialized = json.dumps(d)
+        assert '"class_name"' in serialized
+
+
+# Duplicate PERSON_IDs in PERSON table
+
+
+def test_duplicate_person_ids_in_person_table_do_not_inflate_domain_rows() -> None:
+    """Duplicate PERSON_IDs in PERSON must not cause join-explosion in domain tables."""
+    dup_person_ids = [1847392, 5023471, 9182736, 1847392, 5023471]  # 5 rows, 3 distinct
+    unique_cond_ids = [
+        1847392,
+        5023471,
+        9182736,
+    ]  # each patient has exactly 1 condition row
+
+    person = PhenexPersonTable(
+        ibis.memtable(pd.DataFrame({"PERSON_ID": dup_person_ids}))
+    )
+    cond = CodeTable(
+        ibis.memtable(
+            pd.DataFrame(
+                {
+                    "PERSON_ID": unique_cond_ids,
+                    "EVENT_DATE": [datetime.date(2020, 1, 1)] * 3,
+                    "CODE": ["X"] * 3,
+                }
+            )
+        )
+    )
+    tables = {"PERSON": person, "CONDITION_OCCURRENCE": cond}
+    result = DatabaseSampler(fraction=0.5, seed=42).sample(tables)
+
+    result_ids = set(
+        result["CONDITION_OCCURRENCE"]
+        .table.select("PERSON_ID")
+        .execute()["PERSON_ID"]
+        .tolist()
+    )
+    cond_rows = result["CONDITION_OCCURRENCE"].table.count().execute()
+    assert cond_rows == len(result_ids), (
+        f"Row count ({cond_rows}) exceeds distinct patient count ({len(result_ids)}). "
+        "Duplicate PERSON_IDs in PERSON are inflating domain table rows."
+    )
+
+
+# Edge-value seeds
+
+
+@pytest.mark.parametrize("seed", [-1, -99999, sys.maxsize])
+def test_edge_seed_returns_valid_subset(tables_20: dict, seed: int) -> None:
+    """Negative and sys.maxsize seeds must complete without overflow and stay bounded [0, N]."""
+    result = DatabaseSampler(fraction=0.5, seed=seed).sample(tables_20)
+    count = result["PERSON"].table.count().execute()
+    assert 0 <= count <= 20
 
 
 if __name__ == "__main__":

--- a/phenex/util/database_sampler.py
+++ b/phenex/util/database_sampler.py
@@ -91,8 +91,6 @@ class DatabaseSampler:
         self.person_id_count = None
 
         if self.fraction == 1.0:
-            # No-op: keep every patient â€” identical to having no sampler.
-            # Skip the JOIN so orphan records in domain tables are preserved.
             return dict(mapped_tables)
 
         result: dict[str, Any] = {}
@@ -114,6 +112,10 @@ class DatabaseSampler:
             )
 
         return result
+
+    def __repr__(self) -> str:
+        """Concise representation showing the config that defines the sample."""
+        return f"{self.__class__.__name__}(fraction={self.fraction}, seed={self.seed})"
 
     def to_dict(self) -> dict:
         """Serialize to a JSON-safe dict for cohort snapshot storage."""
@@ -158,6 +160,11 @@ class DatabaseSampler:
             denom_filter = [
                 "  denom      : 0  (fraction=0.0, no patients selected)",
                 "  filter     : fraction=0.0 -> always empty",
+            ]
+        elif self.fraction == 1.0:
+            denom_filter = [
+                "  denom      : 1  (fraction=1.0, all patients selected)",
+                "  filter     : fraction=1.0 -> keep all (hash skipped)",
             ]
         else:
             denom_filter = [

--- a/phenex/util/database_sampler.py
+++ b/phenex/util/database_sampler.py
@@ -90,6 +90,11 @@ class DatabaseSampler:
         self.person_ids = None
         self.person_id_count = None
 
+        if self.fraction == 1.0:
+            # No-op: keep every patient â€” identical to having no sampler.
+            # Skip the JOIN so orphan records in domain tables are preserved.
+            return dict(mapped_tables)
+
         result: dict[str, Any] = {}
         for domain_name, domain in mapped_tables.items():
             if domain is None:
@@ -109,6 +114,14 @@ class DatabaseSampler:
             )
 
         return result
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-safe dict for cohort snapshot storage."""
+        return {
+            "class_name": self.__class__.__name__,
+            "fraction": self.fraction,
+            "seed": self.seed,
+        }
 
     def fetch_person_ids(self) -> list[Any]:
         """Fetch sampled PERSON_IDs from the database into a sorted Python list.
@@ -184,6 +197,9 @@ class DatabaseSampler:
         """
         if self.fraction == 0.0:
             return person_table.limit(0).select("PERSON_ID").distinct()
+
+        if self.fraction == 1.0:
+            return person_table.select("PERSON_ID").distinct()
 
         return (
             person_table.filter(

--- a/phenex/util/serialization/to_dict.py
+++ b/phenex/util/serialization/to_dict.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 from datetime import date, datetime
 
 
@@ -19,14 +20,22 @@ def to_dict(obj) -> dict:
         if param != "self":
             value = getattr(obj, param, None)
             if isinstance(value, list):
-                _dict[param] = [
-                    (
-                        item.to_dict()
-                        if hasattr(item, "to_dict") and callable(item.to_dict)
-                        else item
-                    )
+                items = [
+                    item.to_dict()
+                    if hasattr(item, "to_dict") and callable(item.to_dict)
+                    else item
                     for item in value
                 ]
+                # Sort for deterministic ordering — fixes hash instability when underlying
+                # collection iteration order varies between Python process restarts.
+                try:
+                    items = sorted(
+                        items,
+                        key=lambda x: json.dumps(x, sort_keys=True) if isinstance(x, dict) else str(x),
+                    )
+                except (TypeError, ValueError):
+                    pass
+                _dict[param] = items
             elif isinstance(value, dict):
                 # Handle dictionaries that might contain Codelist objects
                 _dict[param] = {}

--- a/phenex/util/serialization/to_dict.py
+++ b/phenex/util/serialization/to_dict.py
@@ -21,17 +21,22 @@ def to_dict(obj) -> dict:
             value = getattr(obj, param, None)
             if isinstance(value, list):
                 items = [
-                    item.to_dict()
-                    if hasattr(item, "to_dict") and callable(item.to_dict)
-                    else item
+                    (
+                        item.to_dict()
+                        if hasattr(item, "to_dict") and callable(item.to_dict)
+                        else item
+                    )
                     for item in value
                 ]
-                # Sort for deterministic ordering — fixes hash instability when underlying
-                # collection iteration order varies between Python process restarts.
+                # Sort for deterministic ordering, hash stability
                 try:
                     items = sorted(
                         items,
-                        key=lambda x: json.dumps(x, sort_keys=True) if isinstance(x, dict) else str(x),
+                        key=lambda x: (
+                            json.dumps(x, sort_keys=True)
+                            if isinstance(x, dict)
+                            else str(x)
+                        ),
                     )
                 except (TypeError, ValueError):
                     pass


### PR DESCRIPTION
**Adding DatabaseSampler to the Study class** : Studies can now be executed on a reproducible subset of a large database.
- Selection is deterministic and stable. All domains are filtered to the sampled `PERSON` set.
- `Cohort` runs a `sampler_stage` ahead of all other stages.
- Lazy execution aware: changing `fraction`/`seed` invalidates the cache and recomputes.
- `to_dict()` sorts list-valued params so node hashes are stable across Python process restarts.
- Unit coverage for `DatabaseSampler` and `DatabaseSamplerNode`.